### PR TITLE
Install OCaml also on cache hits

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,6 @@ jobs:
 
       - name: Install OCaml
         uses: avsm/setup-ocaml@v1
-        if: steps.opam-cache.outputs.cache-hit != 'true'
         with:
           ocaml-version: ${{ env.OCAML_VERSION }}
 


### PR DESCRIPTION
This should fix the error in CI on `master`.

The problem was that I tried to save time and only installed OCaml on a fresh run, and not when the cache is imported. But that's wrong: We always have to install OCaml, and the imported cache means that this fresh OCaml installation then has access to the `.opam` directory of previous runs.