### PR TITLE
opam file

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        target: [ submodules ]
+        target: [ submodules, opam ]
 
     steps:
 
@@ -33,9 +33,9 @@ jobs:
         uses: actions/cache@v2
         with:
           path: "~/.opam"
-          key: opam-${{ steps.submodule-hash.outputs.HASH }}-${{github.base_ref}}-${{github.ref}} 
+          key: opam-${{ matrix.target }}-${{ steps.submodule-hash.outputs.HASH }}-${{github.base_ref}}-${{github.ref}} 
           restore-keys: |
-            opam-${{ steps.submodule-hash.outputs.HASH }}--refs/heads/${{github.base_ref}}
+            opam-${{ matrix.target }}-${{ steps.submodule-hash.outputs.HASH }}--refs/heads/${{github.base_ref}}
 
       - name: Install OCaml
         uses: avsm/setup-ocaml@v1

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -11,6 +11,13 @@ CertiCoq depends on the following Coq packages:
 
 The dependencies can either be installed manually (from sources or via `opam`) or automatically via provided submodules.
 
+##### Installation of dependencies via opam
+
+All dependencies can be installed directly from the information in the `opam` file:
+
+    # opam repo add coq-released https://coq.inria.fr/opam/released
+    # opam install . --deps-only
+
 ##### Manual installation of dependencies
 
 ###### Ext-lib
@@ -19,11 +26,11 @@ You can install [ExtLib](https://github.com/coq-community/coq-ext-lib) (v0.11.2)
 
 ###### Equations
 
-You can install [Equations](https://github.com/mattam82/Coq-Equations) (v1.2.3) from opam or from their source code or from opam with `opam install coq-equations.1.2.3+8.12`.
+You can install [Equations](https://github.com/mattam82/Coq-Equations) (v1.2.3) from the source code or from opam with `opam install coq-equations.1.2.3+8.12`.
 
 ###### MetaCoq
 
-Currently, MetaCoq needs to be installed manually from the `coq-8.12` branch in [MetaCoq's github](https://github.com/MetaCoq/metacoq/tree/coq-8.12). 
+You can install [MetaCoq](https://metacoq.github.io/) (1.0~beta2+8.12) from the source code or from opam with `opam install coq-metacoq-erasure.1.0~beta2+8.12`.
 
 ##### Installation of dependencies via submodules
 

--- a/opam
+++ b/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+homepage: "https://certicoq.org/"
+dev-repo: "git+https://github.com/CertiCoq/certicoq"
+bug-reports: "https://github.com/CertiCoq/certicoq/issues"
+authors: ["Andrew Appel"
+          "Yannick Forster"
+          "Anvay Grover"
+          "Joomy Korkut"
+          "John Li"
+          "Zoe Paraskevopoulou"
+          "Matthieu Sozeau"
+          "Matthew Weaver"
+          "Abhishek Anand"
+          "Greg Morrisett"
+          "Randy Pollack"
+          "Olivier Savary Belanger"
+  ]
+license: "MIT"
+build: [
+  [make "-j%{jobs}%"]
+]
+install: [
+  [make "install"]
+]
+depends: [
+  "coq" {>= "8.12.1" & < "8.13~"}
+  "coq-equations" {= "1.2.3+8.12"}
+  "ocaml"
+  "coq-metacoq-erasure" {="1.0~beta2+8.12" }
+  "coq-extlib" {="0.11.2"}
+]
+
+synopsis: "A Verified Compiler for Gallina, Written in Gallina "
+url {
+  git: "https://github.com/CertiCoq/certicoq.git"
+}

--- a/opam
+++ b/opam
@@ -27,7 +27,7 @@ depends: [
   "coq-equations" {= "1.2.3+8.12"}
   "ocaml"
   "coq-metacoq-erasure" {="1.0~beta2+8.12" }
-  "coq-extlib" {="0.11.2"}
+  "coq-ext-lib" {="0.11.2"}
 ]
 
 synopsis: "A Verified Compiler for Gallina, Written in Gallina "

--- a/opam
+++ b/opam
@@ -27,7 +27,7 @@ depends: [
   "coq-equations" {= "1.2.3+8.12"}
   "ocaml"
   "coq-metacoq-erasure" {="1.0~beta2+8.12" }
-  "coq-ext-lib" {="0.11.2"}
+  "coq-ext-lib" {="0.11.3"}
 ]
 
 synopsis: "A Verified Compiler for Gallina, Written in Gallina "


### PR DESCRIPTION
This adds an `opam` file and enables `opam`-based compilation in the CI. Also releasing an `opam` package in the future should be straightforward based on the file. 

I updated the `INSTALL.md` file to first suggest installing all dependencies via `opam` directly from the file.

