### PR TITLE
Update metacoq submodule

### DIFF
--- a/clean_extraction.sh
+++ b/clean_extraction.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# For compat with OS X which has an incompatible sed which can be replaced by GNU sed
+SED=`which gsed || which sed`
+
 echo "Cleaning result of extraction"
 
 rm -rf plugin/extraction || true
@@ -29,8 +32,8 @@ mv aST.mli AST.mli
 mv fLT.ml FLT.ml
 mv fLT.mli FLT.mli
 # Work around a compiler bug in module name resolution
-sed -f ../extraction.sed -i compile0.ml
+${SED} -f ../extraction.sed -i compile0.ml
 # We compile with -rectypes, so these definitions are badly interepreted
-sed -e "s/type int = int/type nonrec int = int/" -i integers.mli
-sed -e "s/type int = int/type nonrec int = int/" -i integers.ml
+${SED} -e "s/type int = int/type nonrec int = int/" -i integers.mli
+${SED} -e "s/type int = int/type nonrec int = int/" -i integers.ml
 cd ../..

--- a/make_plugin.sh
+++ b/make_plugin.sh
@@ -13,4 +13,4 @@ else
 fi
 
 cd plugin
-exec make -f Makefile -j`nproc` ${@}
+exec make -f Makefile ${@}

--- a/theories/L1g/toplevel.v
+++ b/theories/L1g/toplevel.v
@@ -25,7 +25,7 @@ Definition wf_program (p : Ast.Env.program) :=
     [] p.2 T ∥.
 
 Definition template_bigstep (p : Ast.Env.program) (v : Ast.term) : Prop :=
-  ∥ Template.WcbvEval.eval p.1 [] p.2 v ∥.
+  ∥ Template.WcbvEval.eval p.1 p.2 v ∥.
 
 #[export] Instance Template_Lang : Lang Ast.Env.program :=
   { Value := Ast.term;


### PR DESCRIPTION
This updates metacoq's submodule to the head of 8.14, for which we will soon release a beta opam package.
This incurs a minor change in the proof: now template-coq's wcbveval is only defined on closed terms and no longer takes a local context index. Apart from that, no changes in the .v files. I could finally run the benchmarks locally, that's great!