### PR TITLE
Performance improvements

### DIFF
--- a/benchmarks/certicoq_pipeline/Makefile
+++ b/benchmarks/certicoq_pipeline/Makefile
@@ -27,7 +27,7 @@ certicoq_pipeline.vo ${GENCFILES} &: certicoq_pipeline.v
 	coqc ${COQOPTS} $<
 
 %.o: %.c
-	gcc -c -I . -I ../../_opam/lib/ocaml -Wno-everything -O2 -fomit-frame-pointer -o $@ $<
+	gcc -g -c -I . -I ../../_opam/lib/ocaml -Wno-everything -O2 -o $@ $<
 
 certicoqc_plugin.cmxs: certicoqc_plugin.cmxa ${CFILES:.c=.o}
 	ocamlfind opt ${OCAMLOPTS} -shared -linkall -o $@ $+

--- a/benchmarks/certicoq_pipeline/certicoq_pipeline.v
+++ b/benchmarks/certicoq_pipeline/certicoq_pipeline.v
@@ -51,6 +51,11 @@ Definition certicoq_pipeline (opts : Options) (p : Template.Ast.Env.program) :=
   compile opts p.
   (* let _ := coq_msg_info ("CertiCoq pipeline succeded.") in *)
   (* tt. *)
+(* CertiCoq Show IR -time -O 1 certicoq_pipeline
+Extract Constants [
+  (* coq_msg_debug => "print_msg_debug", *)
+  coq_msg_info => "print_msg_info"
+]. *)
 
 CertiCoq Compile -time -O 1 certicoq_pipeline
 Extract Constants [

--- a/cplugin/_CoqProject
+++ b/cplugin/_CoqProject
@@ -408,6 +408,8 @@ extraction/string0.ml
 extraction/string0.mli
 extraction/string1.ml
 extraction/string1.mli
+extraction/templateEnvMap.mli
+extraction/templateEnvMap.ml
 extraction/templateProgram.ml
 extraction/templateProgram.mli
 extraction/templateToPCUIC.ml

--- a/cplugin/_CoqProject
+++ b/cplugin/_CoqProject
@@ -97,8 +97,6 @@ extraction/bool.ml
 extraction/bool.mli
 extraction/bracket.ml
 extraction/bracket.mli
-extraction/char0.ml
-extraction/char0.mli
 extraction/byte.mli
 extraction/byte.ml
 extraction/byte0.mli
@@ -307,8 +305,6 @@ extraction/mSetRBT.ml
 extraction/mSetRBT.mli
 extraction/nat0.ml
 extraction/nat0.mli
-extraction/nPeano.ml
-extraction/nPeano.mli
 extraction/number0.ml
 extraction/number0.mli
 extraction/orderedType0.ml
@@ -406,8 +402,6 @@ extraction/stateMonad.ml
 extraction/stateMonad.mli
 extraction/string0.ml
 extraction/string0.mli
-extraction/string1.ml
-extraction/string1.mli
 extraction/templateEnvMap.mli
 extraction/templateEnvMap.ml
 extraction/templateProgram.ml

--- a/cplugin/certicoq_vanilla_plugin.mlpack
+++ b/cplugin/certicoq_vanilla_plugin.mlpack
@@ -85,7 +85,6 @@ Common0
 Extractable
 Logic0
 
-Char0
 Errors0
 
 FLT
@@ -100,8 +99,6 @@ OrdersTac
 POrderedType
 Specif
 StateMonad
-NPeano
-String1
 Monad_utils
 MSetWeakList
 EqdepFacts

--- a/cplugin/certicoq_vanilla_plugin.mlpack
+++ b/cplugin/certicoq_vanilla_plugin.mlpack
@@ -80,12 +80,10 @@ EnvMap
 LiftSubst
 UnivSubst0
 WcbvEval
-EtaExpand
 Pretty
 Common0
 Extractable
 Logic0
-TemplateProgram
 
 Char0
 Errors0
@@ -109,6 +107,11 @@ MSetWeakList
 EqdepFacts
 Utils
 Init
+
+TemplateEnvMap
+TemplateProgram
+EtaExpand
+
 
 Ssreflect
 Ssrbool

--- a/plugin/_CoqProject
+++ b/plugin/_CoqProject
@@ -403,6 +403,8 @@ extraction/string0.ml
 extraction/string0.mli
 extraction/string1.ml
 extraction/string1.mli
+extraction/templateEnvMap.mli
+extraction/templateEnvMap.ml
 extraction/templateProgram.ml
 extraction/templateProgram.mli
 extraction/templateToPCUIC.ml

--- a/plugin/_CoqProject
+++ b/plugin/_CoqProject
@@ -92,8 +92,6 @@ extraction/bool.ml
 extraction/bool.mli
 extraction/bracket.ml
 extraction/bracket.mli
-extraction/char0.ml
-extraction/char0.mli
 extraction/byte.mli
 extraction/byte.ml
 extraction/byte0.mli
@@ -304,8 +302,6 @@ extraction/mSetRBT.ml
 extraction/mSetRBT.mli
 extraction/nat0.ml
 extraction/nat0.mli
-extraction/nPeano.ml
-extraction/nPeano.mli
 extraction/number0.ml
 extraction/number0.mli
 extraction/orderedType0.ml
@@ -401,8 +397,6 @@ extraction/stateMonad.ml
 extraction/stateMonad.mli
 extraction/string0.ml
 extraction/string0.mli
-extraction/string1.ml
-extraction/string1.mli
 extraction/templateEnvMap.mli
 extraction/templateEnvMap.ml
 extraction/templateProgram.ml

--- a/plugin/certicoq_plugin.mlpack
+++ b/plugin/certicoq_plugin.mlpack
@@ -77,12 +77,10 @@ EnvMap
 LiftSubst
 UnivSubst0
 WcbvEval
-EtaExpand
 Pretty
 Common0
 Extractable
 Logic0
-TemplateProgram
 
 Char0
 Errors0
@@ -106,6 +104,10 @@ MSetWeakList
 EqdepFacts
 Utils
 Init
+TemplateEnvMap
+TemplateProgram
+EtaExpand
+
 
 Ssreflect
 Ssrbool

--- a/plugin/certicoq_plugin.mlpack
+++ b/plugin/certicoq_plugin.mlpack
@@ -82,7 +82,6 @@ Common0
 Extractable
 Logic0
 
-Char0
 Errors0
 
 FLT
@@ -97,8 +96,6 @@ OrdersTac
 POrderedType
 Specif
 StateMonad
-NPeano
-String1
 Monad_utils
 MSetWeakList
 EqdepFacts

--- a/theories/Extraction/extraction.v
+++ b/theories/Extraction/extraction.v
@@ -159,6 +159,7 @@ Separate Extraction
          cps.M.elements
          Compiler.pipeline.show_IR.
 
+Recursive Extraction Library Ascii.
 Recursive Extraction Library BinPos.
 Recursive Extraction Library OrdersTac.
 

--- a/theories/ExtractionVanilla/extraction.v
+++ b/theories/ExtractionVanilla/extraction.v
@@ -120,6 +120,7 @@ Separate Extraction
          cps.M.elements
          Compiler.pipeline.show_IR.
 
+Recursive Extraction Library Ascii.
 Recursive Extraction Library BinPos.
 Recursive Extraction Library OrdersTac.
 

--- a/theories/Glue/glue.v
+++ b/theories/Glue/glue.v
@@ -6,10 +6,9 @@ Require Import Coq.ZArith.ZArith
                Coq.Lists.List List_util.
 
 Require Import ExtLib.Structures.Monads
-               ExtLib.Data.Monads.OptionMonad
-               ExtLib.Data.String.
+               ExtLib.Data.Monads.OptionMonad.
 
-From MetaCoq.Template Require Import bytestring BasicAst.
+From MetaCoq.Template Require Import BasicAst.
 Require MetaCoq.Template.All.
 
 Require Import compcert.common.AST
@@ -27,6 +26,8 @@ Require Import L6.cps
                L6_to_Clight
                compM
                glue_utils.
+
+From MetaCoq.Template Require Import bytestring MCString.
 
 Import MonadNotation ListNotations.
 Open Scope monad_scope.
@@ -984,7 +985,7 @@ Section CConstructors.
     match n with
     | O => ret nil
     | S n' =>
-        new_id <- gensym ("arg" ++ String.of_string (nat2string10 n'))%bs ;;
+        new_id <- gensym ("arg" ++ MCString.string_of_nat n')%bs ;;
         rest_id <- make_arg_list' n' ;;
         ret ((new_id, val) :: rest_id)
     end.

--- a/theories/L6_PCPS/Prototype.v
+++ b/theories/L6_PCPS/Prototype.v
@@ -11,7 +11,7 @@ Import MCMonadNotation.
 Module TM := MetaCoq.Template.monad_utils.
 
 From ExtLib.Core Require Import RelDec.
-From ExtLib.Data Require Import Nat List Option Pair String.
+From ExtLib.Data Require Import Nat List Option Pair.
 From ExtLib.Structures Require Import Monoid Functor Applicative Monads Traversable.
 From ExtLib.Data.Monads Require Import IdentityMonad EitherMonad StateMonad.
 
@@ -86,7 +86,7 @@ Instance show_list {A} {s : Show A} : Show (list A) :=
 Definition lookup (n : nat) (xs : list string) : GM string :=
   match nth_error xs n with
   | Some v => ret v
-  | None => raise ("nthM: " +++ of_string (nat2string10 n) ++ " in " ++ show xs)
+  | None => raise ("nthM: " +++ string_of_nat n ++ " in " ++ show xs)
   end.
 
 Definition named_of' (Γ : list string) (tm : term) : GM term :=

--- a/theories/L6_PCPS/cps_show.v
+++ b/theories/L6_PCPS/cps_show.v
@@ -6,12 +6,11 @@
 Require Import Common.AstCommon.
 Require Import List.
 Require Import L6.cps.
-Require Import ExtLib.Data.String.
 Require Import ExtLib.Data.Positive.
 Require Import ExtLib.Structures.Monad.
 Require Import ExtLib.Structures.MonadState.
 Require Import ExtLib.Data.Monads.StateMonad.
-From MetaCoq.Template Require Import bytestring BasicAst. (* For identifier names *)
+From MetaCoq.Template Require Import bytestring MCString BasicAst. (* For identifier names *)
 
 Import MonadNotation.
 
@@ -26,9 +25,9 @@ Section PP.
   Variable (ftag_flag:bool). (* true if print tag *)
 
 (* Convert various numbers to strings *)
-Definition show_nat n := String.of_string (nat2string10 n).
-Definition show_pos x := String.of_string (nat2string10 (Pos.to_nat x)).
-Definition show_binnat x := String.of_string (nat2string10 (BinNat.N.to_nat x)).
+Definition show_nat n := string_of_nat n.
+Definition show_pos x := string_of_positive x.
+Definition show_binnat x := show_nat (BinNat.N.to_nat x).
 
 (* Add a separator [s] inbetween each element of a list [xs] *)
 Fixpoint sep {A} (s:A) (xs:list A) : list A :=


### PR DESCRIPTION
We use lookup maps for a more efficient eta-expansion phase in MetaCoq. This makes the erasure phase drop from 35s to 24s on the certicoq pipeline which goes from template-coq to Clight.

After a bit of profiling, I found that the perf issue in L7 and part of L6 was due to the extlib `nat2string` function which was doing a lot of additions and divisions. Using MetaCoq's `string_of_positive` drops the L7 time on the certicoq_pipeline from 70s to 1s on my computer. The next visible hotspots are the computations of free variables in L6:
it uses a `Module PS := MSetRBT.Make POrderedType.Positive_as_OT.` to keep sets of positive / variable identifiers.
Maybe a good candidate for positive tries?

In the ocaml version of Certicoq, positive is turned into `int` so it is relatively fast, (still gets and sets of maps appear high in the profile), but in the bootstrapped version we have no such luxury yet. In particular the `exp_fv_aux` and `fundefs_fv_aux` functions take a good chunk of the compilation time.
The first profile below is the one of the bootstrapped version, the second is the ocaml one.

This brings down the bootstrapped version to be about 2x slower than the ocaml one, which is not too bad!

![trace](https://user-images.githubusercontent.com/98373/178610614-7a4a88f5-8e2b-4b35-8ee6-090cd4e7a0a0.jpg)

<img width="972" alt="Screenshot 2022-07-13 at 00 48 28" src="https://user-images.githubusercontent.com/98373/178611362-8639e0fd-73c0-46e6-9208-3aa98eea9efe.png">

