### PR TITLE
OPAM: requires Clang

### DIFF
--- a/coq-certicoq.opam
+++ b/coq-certicoq.opam
@@ -31,6 +31,7 @@ install: [
 ]
 depends: [
   "ocaml"
+  "conf-clang"
   "stdlib-shims"
   "coq" {>= "8.17" & < "8.18~"}
   "coq-compcert" {= "3.12"}


### PR DESCRIPTION
https://github.com/CertiCoq/certicoq/blob/87dff37df58f426fa0c267ac45908f0ce40e7b17/bootstrap/certicoqc/Makefile#L1 https://github.com/CertiCoq/certicoq/blob/87dff37df58f426fa0c267ac45908f0ce40e7b17/bootstrap/certicoqc/Makefile#L54-L55

    # clang  -fPIC -g -c -I . -I ../../plugin/runtime -I /home/coq/.opam/4.07.1+flambda/lib/ocaml -w -Wno-everything -O2 -o certicoqc_wrapper.o certicoqc_wrapper.c
    # make[2]: clang: No such file or directory
    # make[2]: *** [Makefile:55: certicoqc_wrapper.o] Error 127