### PR TITLE
ANF codegen should return values instead of putting them in args[1]

### DIFF
--- a/benchmarks/basics.c
+++ b/benchmarks/basics.c
@@ -1,65 +1,47 @@
-
+#include "values.h"
+struct closure;
+struct stack_frame;
 struct thread_info;
-struct Coq_Init_Datatypes_O_args;
-struct Coq_Init_Datatypes_S_args;
-struct Coq_Init_Datatypes_nil_args;
-struct Coq_Init_Datatypes_cons_args;
-struct Coq_Init_Datatypes_true_args;
-struct Coq_Init_Datatypes_false_args;
+struct closure {
+  value (*func)(struct thread_info, value, value);
+  value env;
+};
+
+struct stack_frame {
+  value *next;
+  value *root;
+  struct stack_frame *prev;
+};
+
 struct thread_info {
-  unsigned long long *alloc;
-  unsigned long long *limit;
+  value *alloc;
+  value *limit;
   struct heap *heap;
-  unsigned long long args[1024];
-};
-
-struct Coq_Init_Datatypes_O_args {
-};
-
-struct Coq_Init_Datatypes_S_args {
-  unsigned long long Coq_Init_Datatypes_S_arg_0;
-};
-
-struct Coq_Init_Datatypes_nil_args {
-};
-
-struct Coq_Init_Datatypes_cons_args {
-  unsigned long long Coq_Init_Datatypes_cons_arg_0;
-  unsigned long long Coq_Init_Datatypes_cons_arg_1;
-};
-
-struct Coq_Init_Datatypes_true_args {
-};
-
-struct Coq_Init_Datatypes_false_args {
+  value args[1024];
+  struct stack_frame *fp;
+  unsigned long long nalloc;
 };
 
 extern int printf(signed char *);
-extern _Bool is_ptr(unsigned long long);
-unsigned int get_unboxed_ordinal(unsigned long long);
-unsigned int get_boxed_ordinal(unsigned long long);
-unsigned long long make_Coq_Init_Datatypes_nat_O(void);
-unsigned long long make_Coq_Init_Datatypes_nat_S(unsigned long long, unsigned long long *);
-unsigned long long alloc_make_Coq_Init_Datatypes_nat_S(struct thread_info *, unsigned long long);
-unsigned long long make_Coq_Init_Datatypes_list_nil(void);
-unsigned long long make_Coq_Init_Datatypes_list_cons(unsigned long long, unsigned long long, unsigned long long *);
-unsigned long long alloc_make_Coq_Init_Datatypes_list_cons(struct thread_info *, unsigned long long, unsigned long long);
-unsigned long long make_Coq_Init_Datatypes_bool_true(void);
-unsigned long long make_Coq_Init_Datatypes_bool_false(void);
-unsigned int get_Coq_Init_Datatypes_nat_tag(unsigned long long);
-unsigned int get_Coq_Init_Datatypes_list_tag(unsigned long long);
-unsigned int get_Coq_Init_Datatypes_bool_tag(unsigned long long);
-struct Coq_Init_Datatypes_O_args *get_Coq_Init_Datatypes_O_args(unsigned long long);
-struct Coq_Init_Datatypes_S_args *get_Coq_Init_Datatypes_S_args(unsigned long long);
-struct Coq_Init_Datatypes_nil_args *get_Coq_Init_Datatypes_nil_args(unsigned long long);
-struct Coq_Init_Datatypes_cons_args *get_Coq_Init_Datatypes_cons_args(unsigned long long);
-struct Coq_Init_Datatypes_true_args *get_Coq_Init_Datatypes_true_args(unsigned long long);
-struct Coq_Init_Datatypes_false_args *get_Coq_Init_Datatypes_false_args(unsigned long long);
-void print_Coq_Init_Datatypes_nat(unsigned long long);
-void print_Coq_Init_Datatypes_list(unsigned long long, void (*)(unsigned long long));
-void print_Coq_Init_Datatypes_bool(unsigned long long);
-void halt(struct thread_info *, unsigned long long, unsigned long long);
-unsigned long long call(struct thread_info *, unsigned long long, unsigned long long);
+extern _Bool is_ptr(value);
+unsigned int get_unboxed_ordinal(value);
+unsigned int get_boxed_ordinal(value);
+value *get_args(value);
+value make_Coq_Init_Datatypes_nat_O(void);
+value make_Coq_Init_Datatypes_nat_S(value, value *);
+value alloc_make_Coq_Init_Datatypes_nat_S(struct thread_info *, value);
+value make_Coq_Init_Datatypes_list_nil(void);
+value make_Coq_Init_Datatypes_list_cons(value, value, value *);
+value alloc_make_Coq_Init_Datatypes_list_cons(struct thread_info *, value, value);
+value make_Coq_Init_Datatypes_bool_true(void);
+value make_Coq_Init_Datatypes_bool_false(void);
+unsigned int get_Coq_Init_Datatypes_nat_tag(value);
+unsigned int get_Coq_Init_Datatypes_list_tag(value);
+unsigned int get_Coq_Init_Datatypes_bool_tag(value);
+void print_Coq_Init_Datatypes_nat(value);
+void print_Coq_Init_Datatypes_list(value, void (*)(value));
+void print_Coq_Init_Datatypes_bool(value);
+value call(struct thread_info *, value, value);
 signed char const lparen_lit[2] = { 40, 0, };
 
 signed char const rparen_lit[2] = { 41, 0, };
@@ -74,14 +56,19 @@ signed char const unk_lit[6] = { 60, 117, 110, 107, 62, 0, };
 
 signed char const prop_lit[7] = { 60, 112, 114, 111, 112, 62, 0, };
 
-unsigned int get_unboxed_ordinal(unsigned long long $v)
+unsigned int get_unboxed_ordinal(value $v)
 {
-  return $v >> 1LLU;
+  return (unsigned long long) $v >> 1LL;
 }
 
-unsigned int get_boxed_ordinal(unsigned long long $v)
+unsigned int get_boxed_ordinal(value $v)
 {
-  return *((unsigned long long *) $v + 18446744073709551615LLU) & 255LLU;
+  return *((unsigned long long *) $v + -1LL) & 255LL;
+}
+
+value *get_args(value $v)
+{
+  return (value *) $v;
 }
 
 signed char const names_of_Coq_Init_Datatypes_nat[2][2] = { 79, 0, 83, 0,
@@ -93,63 +80,63 @@ signed char const names_of_Coq_Init_Datatypes_list[2][5] = { 110, 105, 108,
 signed char const names_of_Coq_Init_Datatypes_bool[2][6] = { 116, 114, 117,
   101, 0, 0, 102, 97, 108, 115, 101, 0, /* skip 0 */ };
 
-unsigned long long make_Coq_Init_Datatypes_nat_O(void)
+value make_Coq_Init_Datatypes_nat_O(void)
 {
   return 1;
 }
 
-unsigned long long make_Coq_Init_Datatypes_nat_S(unsigned long long $arg0, unsigned long long *$argv)
+value make_Coq_Init_Datatypes_nat_S(value $arg0, value *$argv)
 {
-  *((unsigned long long *) $argv + 0LLU) = 1024LLU;
-  *((unsigned long long *) $argv + 1LLU) = $arg0;
-  return $argv + 1LLU;
+  *($argv + 0LL) = (value) 1024LL;
+  *($argv + 1LL) = $arg0;
+  return $argv + 1LL;
 }
 
-unsigned long long alloc_make_Coq_Init_Datatypes_nat_S(struct thread_info *$tinfo, unsigned long long $arg0)
+value alloc_make_Coq_Init_Datatypes_nat_S(struct thread_info *$tinfo, value $arg0)
 {
-  register unsigned long long *$argv;
+  register value *$argv;
   $argv = (*$tinfo).alloc;
-  *((unsigned long long *) $argv + 0LLU) = 1024LLU;
-  *((unsigned long long *) $argv + 1LLU) = $arg0;
-  (*$tinfo).alloc = (*$tinfo).alloc + 2LLU;
-  return $argv + 1LLU;
+  *($argv + 0LL) = 1024LL;
+  *($argv + 1LL) = $arg0;
+  (*$tinfo).alloc = (*$tinfo).alloc + 2LL;
+  return $argv + 1LL;
 }
 
-unsigned long long make_Coq_Init_Datatypes_list_nil(void)
+value make_Coq_Init_Datatypes_list_nil(void)
 {
   return 1;
 }
 
-unsigned long long make_Coq_Init_Datatypes_list_cons(unsigned long long $arg0, unsigned long long $arg1, unsigned long long *$argv)
+value make_Coq_Init_Datatypes_list_cons(value $arg0, value $arg1, value *$argv)
 {
-  *((unsigned long long *) $argv + 0LLU) = 2048LLU;
-  *((unsigned long long *) $argv + 1LLU) = $arg0;
-  *((unsigned long long *) $argv + 2LLU) = $arg1;
-  return $argv + 1LLU;
+  *($argv + 0LL) = (value) 2048LL;
+  *($argv + 1LL) = $arg0;
+  *($argv + 2LL) = $arg1;
+  return $argv + 1LL;
 }
 
-unsigned long long alloc_make_Coq_Init_Datatypes_list_cons(struct thread_info *$tinfo, unsigned long long $arg0, unsigned long long $arg1)
+value alloc_make_Coq_Init_Datatypes_list_cons(struct thread_info *$tinfo, value $arg0, value $arg1)
 {
-  register unsigned long long *$argv;
+  register value *$argv;
   $argv = (*$tinfo).alloc;
-  *((unsigned long long *) $argv + 0LLU) = 2048LLU;
-  *((unsigned long long *) $argv + 1LLU) = $arg0;
-  *((unsigned long long *) $argv + 2LLU) = $arg1;
-  (*$tinfo).alloc = (*$tinfo).alloc + 3LLU;
-  return $argv + 1LLU;
+  *($argv + 0LL) = 2048LL;
+  *($argv + 1LL) = $arg0;
+  *($argv + 2LL) = $arg1;
+  (*$tinfo).alloc = (*$tinfo).alloc + 3LL;
+  return $argv + 1LL;
 }
 
-unsigned long long make_Coq_Init_Datatypes_bool_true(void)
+value make_Coq_Init_Datatypes_bool_true(void)
 {
   return 1;
 }
 
-unsigned long long make_Coq_Init_Datatypes_bool_false(void)
+value make_Coq_Init_Datatypes_bool_false(void)
 {
   return 3;
 }
 
-unsigned int get_Coq_Init_Datatypes_nat_tag(unsigned long long $v)
+unsigned int get_Coq_Init_Datatypes_nat_tag(value $v)
 {
   register _Bool $b;
   register unsigned int $t;
@@ -171,7 +158,7 @@ unsigned int get_Coq_Init_Datatypes_nat_tag(unsigned long long $v)
   }
 }
 
-unsigned int get_Coq_Init_Datatypes_list_tag(unsigned long long $v)
+unsigned int get_Coq_Init_Datatypes_list_tag(value $v)
 {
   register _Bool $b;
   register unsigned int $t;
@@ -193,44 +180,14 @@ unsigned int get_Coq_Init_Datatypes_list_tag(unsigned long long $v)
   }
 }
 
-unsigned int get_Coq_Init_Datatypes_bool_tag(unsigned long long $v)
+unsigned int get_Coq_Init_Datatypes_bool_tag(value $v)
 {
   register unsigned int $t;
   $t = get_unboxed_ordinal($v);
   return $t;
 }
 
-struct Coq_Init_Datatypes_O_args *get_Coq_Init_Datatypes_O_args(unsigned long long $v)
-{
-  return (struct Coq_Init_Datatypes_O_args *) 0;
-}
-
-struct Coq_Init_Datatypes_S_args *get_Coq_Init_Datatypes_S_args(unsigned long long $v)
-{
-  return (struct Coq_Init_Datatypes_S_args *) $v;
-}
-
-struct Coq_Init_Datatypes_nil_args *get_Coq_Init_Datatypes_nil_args(unsigned long long $v)
-{
-  return (struct Coq_Init_Datatypes_nil_args *) 0;
-}
-
-struct Coq_Init_Datatypes_cons_args *get_Coq_Init_Datatypes_cons_args(unsigned long long $v)
-{
-  return (struct Coq_Init_Datatypes_cons_args *) $v;
-}
-
-struct Coq_Init_Datatypes_true_args *get_Coq_Init_Datatypes_true_args(unsigned long long $v)
-{
-  return (struct Coq_Init_Datatypes_true_args *) 0;
-}
-
-struct Coq_Init_Datatypes_false_args *get_Coq_Init_Datatypes_false_args(unsigned long long $v)
-{
-  return (struct Coq_Init_Datatypes_false_args *) 0;
-}
-
-void print_Coq_Init_Datatypes_nat(unsigned long long $v)
+void print_Coq_Init_Datatypes_nat(value $v)
 {
   register unsigned int $tag;
   register void *$args;
@@ -240,18 +197,18 @@ void print_Coq_Init_Datatypes_nat(unsigned long long $v)
       printf(*(names_of_Coq_Init_Datatypes_nat + $tag));
       break;
     case 1:
-      $args = get_Coq_Init_Datatypes_S_args($v);
+      $args = get_args($v);
       printf(lparen_lit);
       printf(*(names_of_Coq_Init_Datatypes_nat + $tag));
       printf(space_lit);
-      print_Coq_Init_Datatypes_nat(*((unsigned long long *) $args + 0));
+      print_Coq_Init_Datatypes_nat(*((value *) $args + 0));
       printf(rparen_lit);
       break;
     
   }
 }
 
-void print_Coq_Init_Datatypes_list(unsigned long long $v, void $print_param_A(unsigned long long))
+void print_Coq_Init_Datatypes_list(value $v, void $print_param_A(value))
 {
   register unsigned int $tag;
   register void *$args;
@@ -261,45 +218,37 @@ void print_Coq_Init_Datatypes_list(unsigned long long $v, void $print_param_A(un
       printf(*(names_of_Coq_Init_Datatypes_list + $tag));
       break;
     case 1:
-      $args = get_Coq_Init_Datatypes_cons_args($v);
+      $args = get_args($v);
       printf(lparen_lit);
       printf(*(names_of_Coq_Init_Datatypes_list + $tag));
       printf(space_lit);
-      $print_param_A(*((unsigned long long *) $args + 0));
+      $print_param_A(*((value *) $args + 0));
       printf(space_lit);
-      print_Coq_Init_Datatypes_list
-        (*((unsigned long long *) $args + 1), $print_param_A);
+      print_Coq_Init_Datatypes_list(*((value *) $args + 1), $print_param_A);
       printf(rparen_lit);
       break;
     
   }
 }
 
-void print_Coq_Init_Datatypes_bool(unsigned long long $v)
+void print_Coq_Init_Datatypes_bool(value $v)
 {
   register unsigned int $tag;
   $tag = get_Coq_Init_Datatypes_bool_tag($v);
   printf(*(names_of_Coq_Init_Datatypes_bool + $tag));
 }
 
-void halt(struct thread_info *$tinfo, unsigned long long $env, unsigned long long $arg)
-{
-  *((unsigned long long *) (*$tinfo).args + 1LLU) = $arg;
-  return;
-}
-
-unsigned long long const halt_clo[2] = { &halt, 1LL, };
-
-unsigned long long call(struct thread_info *$tinfo, unsigned long long $clo, unsigned long long $arg)
+value call(struct thread_info *$tinfo, value $clo, value $arg)
 {
   register unsigned long long *$f;
   register unsigned long long *$envi;
-  $f = *((unsigned long long *) $clo + 0LLU);
-  $envi = *((unsigned long long *) $clo + 1LLU);
-  ((void (*)(struct thread_info *, unsigned long long, unsigned long long)) 
-    $f)
+  register value $tmp;
+  $f = (*((struct closure *) $clo)).func;
+  $envi = (*((struct closure *) $clo)).env;
+  $tmp =
+    ((value (*)(struct thread_info *, value, value)) $f)
     ($tinfo, $envi, $arg);
-  return *((unsigned long long *) (*$tinfo).args + 1LLU);
+  return $tmp;
 }
 
 

--- a/benchmarks/basics.h
+++ b/benchmarks/basics.h
@@ -1,63 +1,45 @@
-
+#include "values.h"
+struct closure;
+struct stack_frame;
 struct thread_info;
-struct Coq_Init_Datatypes_O_args;
-struct Coq_Init_Datatypes_S_args;
-struct Coq_Init_Datatypes_nil_args;
-struct Coq_Init_Datatypes_cons_args;
-struct Coq_Init_Datatypes_true_args;
-struct Coq_Init_Datatypes_false_args;
+struct closure {
+  value (*func)(struct thread_info, value, value);
+  value env;
+};
+
+struct stack_frame {
+  value *next;
+  value *root;
+  struct stack_frame *prev;
+};
+
 struct thread_info {
-  unsigned long long *alloc;
-  unsigned long long *limit;
+  value *alloc;
+  value *limit;
   struct heap *heap;
-  unsigned long long args[1024];
+  value args[1024];
+  struct stack_frame *fp;
+  unsigned long long nalloc;
 };
 
-struct Coq_Init_Datatypes_O_args {
-};
-
-struct Coq_Init_Datatypes_S_args {
-  unsigned long long Coq_Init_Datatypes_S_arg_0;
-};
-
-struct Coq_Init_Datatypes_nil_args {
-};
-
-struct Coq_Init_Datatypes_cons_args {
-  unsigned long long Coq_Init_Datatypes_cons_arg_0;
-  unsigned long long Coq_Init_Datatypes_cons_arg_1;
-};
-
-struct Coq_Init_Datatypes_true_args {
-};
-
-struct Coq_Init_Datatypes_false_args {
-};
-
-extern unsigned int get_unboxed_ordinal(unsigned long long);
-extern unsigned int get_boxed_ordinal(unsigned long long);
-extern unsigned long long make_Coq_Init_Datatypes_nat_O(void);
-extern unsigned long long make_Coq_Init_Datatypes_nat_S(unsigned long long, unsigned long long *);
-extern unsigned long long alloc_make_Coq_Init_Datatypes_nat_S(struct thread_info *, unsigned long long);
-extern unsigned long long make_Coq_Init_Datatypes_list_nil(void);
-extern unsigned long long make_Coq_Init_Datatypes_list_cons(unsigned long long, unsigned long long, unsigned long long *);
-extern unsigned long long alloc_make_Coq_Init_Datatypes_list_cons(struct thread_info *, unsigned long long, unsigned long long);
-extern unsigned long long make_Coq_Init_Datatypes_bool_true(void);
-extern unsigned long long make_Coq_Init_Datatypes_bool_false(void);
-extern unsigned int get_Coq_Init_Datatypes_nat_tag(unsigned long long);
-extern unsigned int get_Coq_Init_Datatypes_list_tag(unsigned long long);
-extern unsigned int get_Coq_Init_Datatypes_bool_tag(unsigned long long);
-extern struct Coq_Init_Datatypes_O_args *get_Coq_Init_Datatypes_O_args(unsigned long long);
-extern struct Coq_Init_Datatypes_S_args *get_Coq_Init_Datatypes_S_args(unsigned long long);
-extern struct Coq_Init_Datatypes_nil_args *get_Coq_Init_Datatypes_nil_args(unsigned long long);
-extern struct Coq_Init_Datatypes_cons_args *get_Coq_Init_Datatypes_cons_args(unsigned long long);
-extern struct Coq_Init_Datatypes_true_args *get_Coq_Init_Datatypes_true_args(unsigned long long);
-extern struct Coq_Init_Datatypes_false_args *get_Coq_Init_Datatypes_false_args(unsigned long long);
-extern void print_Coq_Init_Datatypes_nat(unsigned long long);
-extern void print_Coq_Init_Datatypes_list(unsigned long long, void (*)(unsigned long long));
-extern void print_Coq_Init_Datatypes_bool(unsigned long long);
-extern void halt(struct thread_info *, unsigned long long, unsigned long long);
-extern unsigned long long call(struct thread_info *, unsigned long long, unsigned long long);
+extern unsigned int get_unboxed_ordinal(value);
+extern unsigned int get_boxed_ordinal(value);
+extern value *get_args(value);
+extern value make_Coq_Init_Datatypes_nat_O(void);
+extern value make_Coq_Init_Datatypes_nat_S(value, value *);
+extern value alloc_make_Coq_Init_Datatypes_nat_S(struct thread_info *, value);
+extern value make_Coq_Init_Datatypes_list_nil(void);
+extern value make_Coq_Init_Datatypes_list_cons(value, value, value *);
+extern value alloc_make_Coq_Init_Datatypes_list_cons(struct thread_info *, value, value);
+extern value make_Coq_Init_Datatypes_bool_true(void);
+extern value make_Coq_Init_Datatypes_bool_false(void);
+extern unsigned int get_Coq_Init_Datatypes_nat_tag(value);
+extern unsigned int get_Coq_Init_Datatypes_list_tag(value);
+extern unsigned int get_Coq_Init_Datatypes_bool_tag(value);
+extern void print_Coq_Init_Datatypes_nat(value);
+extern void print_Coq_Init_Datatypes_list(value, void (*)(value));
+extern void print_Coq_Init_Datatypes_bool(value);
+extern value call(struct thread_info *, value, value);
 extern signed char const lparen_lit[2];
 
 extern signed char const rparen_lit[2];
@@ -77,7 +59,5 @@ extern signed char const names_of_Coq_Init_Datatypes_nat[2][2];
 extern signed char const names_of_Coq_Init_Datatypes_list[2][5];
 
 extern signed char const names_of_Coq_Init_Datatypes_bool[2][6];
-
-extern unsigned long long const halt_clo[2];
 
 

--- a/benchmarks/binom_main.c
+++ b/benchmarks/binom_main.c
@@ -8,8 +8,6 @@ extern void body(struct thread_info *);
 
 extern void print_Coq_Init_Datatypes_nat(unsigned long long);
 
-extern value args[];
-
 _Bool is_ptr(value s) {
   return (_Bool) Is_block(s);
 }
@@ -28,11 +26,10 @@ int main(int argc, char *argv[]) {
   // Run Coq program
   for (int i = 0; i < n; i ++) {
     tinfo = make_tinfo();
-    body(tinfo);
+    val = body(tinfo);
   }
   end = clock();
 
-  val = tinfo -> args[1];
   // TODO : fold over nat to print the C int
   print_Coq_Init_Datatypes_nat(val);
   printf("\n");

--- a/benchmarks/binom_main.c
+++ b/benchmarks/binom_main.c
@@ -4,7 +4,7 @@
 #include <time.h>
 
 
-extern void body(struct thread_info *);
+extern value body(struct thread_info *);
 
 extern void print_Coq_Init_Datatypes_nat(unsigned long long);
 

--- a/benchmarks/color_main.c
+++ b/benchmarks/color_main.c
@@ -10,8 +10,6 @@ extern void print_Coq_Numbers_BinNums_Z(unsigned long long);
 
 extern void print_Coq_Init_Datatypes_prod(unsigned long long, void (*)(unsigned long long), void (*)(unsigned long long));
 
-extern value args[];
-
 _Bool is_ptr(value s) {
   return (_Bool) Is_block(s);
 }
@@ -30,11 +28,10 @@ int main(int argc, char *argv[]) {
   // Run Coq program
   for (int i = 0; i < n; i ++) {
     tinfo = make_tinfo();
-    body(tinfo);
+    val = body(tinfo);
   }
   end = clock();
 
-  val = tinfo -> args[1];
   // TODO : fold over nat to print the C int
   print_Coq_Init_Datatypes_prod(val, print_Coq_Numbers_BinNums_Z, print_Coq_Numbers_BinNums_Z);
   printf("\n");

--- a/benchmarks/color_main.c
+++ b/benchmarks/color_main.c
@@ -4,7 +4,7 @@
 #include <time.h>
 
 
-extern void body(struct thread_info *);
+extern value body(struct thread_info *);
 
 extern void print_Coq_Numbers_BinNums_Z(unsigned long long);
 

--- a/benchmarks/demo1_main.c
+++ b/benchmarks/demo1_main.c
@@ -10,8 +10,6 @@ extern void print_Coq_Init_Datatypes_list(unsigned long long, void (*)(unsigned 
 
 extern void print_Coq_Init_Datatypes_bool(unsigned long long);
 
-extern value args[];
-
 _Bool is_ptr(value s) {
   return (_Bool) Is_block(s);
 }
@@ -30,11 +28,10 @@ int main(int argc, char *argv[]) {
   // Run Coq program
   for (int i = 0; i < n; i ++) {
     tinfo = make_tinfo();
-    body(tinfo);
+    val = body(tinfo);
   }
   end = clock();
 
-  val = tinfo -> args[1];
   print_Coq_Init_Datatypes_list(val, print_Coq_Init_Datatypes_bool);
   printf("\n");
 

--- a/benchmarks/demo1_main.c
+++ b/benchmarks/demo1_main.c
@@ -4,7 +4,7 @@
 #include <time.h>
 
 
-extern void body(struct thread_info *);
+extern value body(struct thread_info *);
 
 extern void print_Coq_Init_Datatypes_list(unsigned long long, void (*)(unsigned long long));
 

--- a/benchmarks/demo2_main.c
+++ b/benchmarks/demo2_main.c
@@ -10,8 +10,6 @@ extern void print_Coq_Init_Datatypes_list(unsigned long long, void (*)(unsigned 
 
 extern void print_Coq_Init_Datatypes_bool(unsigned long long);
 
-extern value args[];
-
 _Bool is_ptr(value s) {
   return (_Bool) Is_block(s);
 }
@@ -30,11 +28,10 @@ int main(int argc, char *argv[]) {
   // Run Coq program
   for (int i = 0; i < n; i ++) {
     tinfo = make_tinfo();
-    body(tinfo);
+    val = body(tinfo);
   }
   end = clock();
 
-  val = tinfo -> args[1];
   print_Coq_Init_Datatypes_list(val, print_Coq_Init_Datatypes_bool);
   printf("\n");
 

--- a/benchmarks/demo2_main.c
+++ b/benchmarks/demo2_main.c
@@ -4,7 +4,7 @@
 #include <time.h>
 
 
-extern void body(struct thread_info *);
+extern value body(struct thread_info *);
 
 extern void print_Coq_Init_Datatypes_list(unsigned long long, void (*)(unsigned long long));
 

--- a/benchmarks/demo3_main.c
+++ b/benchmarks/demo3_main.c
@@ -5,7 +5,7 @@
 #include <time.h>
 
 /* TODO: This should be imported with include. */
-extern void body(struct thread_info *);
+extern value body(struct thread_info *);
 
 extern struct thread_info;
 extern void print_Coq_Init_Datatypes_list(unsigned long long, void (*)(unsigned long long));

--- a/benchmarks/demo3_main.c
+++ b/benchmarks/demo3_main.c
@@ -6,7 +6,6 @@
 
 /* TODO: This should be imported with include. */
 extern void body(struct thread_info *);
-extern value args[];
 
 extern struct thread_info;
 extern void print_Coq_Init_Datatypes_list(unsigned long long, void (*)(unsigned long long));
@@ -46,16 +45,12 @@ int main(int argc, char *argv[]) {
   start = clock();
 
   // Run Coq program
-  body(tinfo);
+  andb = body(tinfo);
   end = clock();
-
-  /* Get the andb function from the arguments array */
-  andb = tinfo -> args[1];
 
   /* Generate booleans*/
   value b = make_Coq_Init_Datatypes_bool_true ();
   value c = make_Coq_Init_Datatypes_bool_false ();
-
 
   printf("The original booleans.\n");
   print_Coq_Init_Datatypes_bool(b);

--- a/benchmarks/list_sum_main.c
+++ b/benchmarks/list_sum_main.c
@@ -28,11 +28,10 @@ int main(int argc, char *argv[]) {
   // Run Coq program
   for (int i = 0; i < n; i ++) {
     tinfo = make_tinfo();
-    body(tinfo);
+    val = body(tinfo);
   }
   end = clock();
 
-  val = tinfo -> args[1];
   // TODO : fold over nat to print the C int
   print_Coq_Init_Datatypes_nat(val);
   printf("\n");

--- a/benchmarks/list_sum_main.c
+++ b/benchmarks/list_sum_main.c
@@ -4,7 +4,7 @@
 #include <time.h>
 
 
-extern void body(struct thread_info *);
+extern value body(struct thread_info *);
 
 extern void print_Coq_Init_Datatypes_nat(unsigned long long);
 

--- a/benchmarks/sha_fast_main.c
+++ b/benchmarks/sha_fast_main.c
@@ -6,8 +6,6 @@
 
 extern void body(struct thread_info *);
 
-extern value args[];
-
 _Bool is_ptr(value s) {
   return (_Bool) Is_block(s);
 }
@@ -31,7 +29,6 @@ int main(int argc, char *argv[]) {
   end = clock();
 
   /* TODO write string printers */
-  /* val = tinfo -> args[1]; */
   /* print_Coq_Init_Datatypes_list(val, print_Coq_Init_Datatypes_bool); */
   /* printf("\n"); */
 

--- a/benchmarks/sha_fast_main.c
+++ b/benchmarks/sha_fast_main.c
@@ -4,7 +4,7 @@
 #include <time.h>
 
 
-extern void body(struct thread_info *);
+extern value body(struct thread_info *);
 
 _Bool is_ptr(value s) {
   return (_Bool) Is_block(s);

--- a/benchmarks/test_primitive_main.c
+++ b/benchmarks/test_primitive_main.c
@@ -6,8 +6,6 @@
 
 extern void body(struct thread_info *);
 
-extern value args[];
-
 _Bool is_ptr(value s) {
   return (_Bool) Is_block(s);
 }
@@ -26,11 +24,10 @@ int main(int argc, char *argv[]) {
   // Run Coq program
   for (int i = 0; i < n; i ++) {
     tinfo = make_tinfo();
-    body(tinfo);
+    val = body(tinfo);
   }
   end = clock();
 
-  val = tinfo -> args[1];
   printf("%llu\n", ( (unsigned long long) val >> 1));
 
   sec = (double)(end - start)/CLOCKS_PER_SEC;

--- a/benchmarks/test_primitive_main.c
+++ b/benchmarks/test_primitive_main.c
@@ -4,7 +4,7 @@
 #include <time.h>
 
 
-extern void body(struct thread_info *);
+extern value body(struct thread_info *);
 
 _Bool is_ptr(value s) {
   return (_Bool) Is_block(s);

--- a/benchmarks/vs_easy_main.c
+++ b/benchmarks/vs_easy_main.c
@@ -12,8 +12,6 @@ extern void print_CertiCoq_Benchmarks_lib_vs_space_atom(unsigned long long);
 
 extern unsigned int get_Coq_Init_Datatypes_list_tag(unsigned long long);
 
-extern value args[];
-
 _Bool is_ptr(value s) {
   return (_Bool) Is_block(s);
 }
@@ -61,11 +59,10 @@ int main(int argc, char *argv[]) {
   // Run Coq program
   for (int i = 0; i < n; i ++) {
     tinfo = make_tinfo();
-    body(tinfo);
+    val = body(tinfo);
   }
   end = clock();
 
-  val = tinfo -> args[1];
   // TODO : fold over nat to print the C int
   print_Coq_Init_Datatypes_bool(val);
   printf("\n");

--- a/benchmarks/vs_easy_main.c
+++ b/benchmarks/vs_easy_main.c
@@ -4,7 +4,7 @@
 #include <time.h>
 
 
-extern void body(struct thread_info *);
+extern value body(struct thread_info *);
 
 extern void print_Coq_Init_Datatypes_bool(unsigned long long);
 

--- a/benchmarks/vs_hard_main.c
+++ b/benchmarks/vs_hard_main.c
@@ -8,8 +8,6 @@ extern void body(struct thread_info *);
 
 extern void print_Coq_Init_Datatypes_bool(unsigned long long);
 
-extern value args[];
-
 _Bool is_ptr(value s) {
   return (_Bool) Is_block(s);
 }
@@ -42,11 +40,10 @@ int main(int argc, char *argv[]) {
   // Run Coq program
   for (int i = 0; i < n; i ++) {
     tinfo = make_tinfo();
-    body(tinfo);
+    val = body(tinfo);
   }
   end = clock();
 
-  val = tinfo -> args[1];
   // TODO : fold over nat to print the C int
   print_Coq_Init_Datatypes_bool(val);
   printf("\n");

--- a/benchmarks/vs_hard_main.c
+++ b/benchmarks/vs_hard_main.c
@@ -4,7 +4,7 @@
 #include <time.h>
 
 
-extern void body(struct thread_info *);
+extern value body(struct thread_info *);
 
 extern void print_Coq_Init_Datatypes_bool(unsigned long long);
 

--- a/bootstrap/certicoqc/certicoqc_wrapper.c
+++ b/bootstrap/certicoqc/certicoqc_wrapper.c
@@ -8,8 +8,6 @@
 
 extern value body(struct thread_info *);
 
-extern value args[];
-
 extern value *call(struct thread_info *, value, value);
 
 _Bool is_ptr(value s) {

--- a/bootstrap/certicoqchk/certicoqchk_wrapper.c
+++ b/bootstrap/certicoqchk/certicoqchk_wrapper.c
@@ -8,8 +8,6 @@
 
 extern value body(struct thread_info *);
 
-extern value args[];
-
 extern value *call(struct thread_info *, value, value);
 
 _Bool is_ptr(value s) {

--- a/theories/Codegen/toplevel.v
+++ b/theories/Codegen/toplevel.v
@@ -19,6 +19,7 @@ Definition heapInfIdent:positive := 95.
 Definition numArgsIdent:positive := 97.
 Definition isptrIdent:positive := 82.
 Definition caseIdent:positive := 83.
+Definition resultIdent:positive := 93.
 
 Definition stackframeTIdent:positive := 78. (* the stack_frame type *)
 Definition frameIdent:positive := 79. (* the stack frame of the current function *)
@@ -64,7 +65,7 @@ Definition Clight_trans_ANF (prims : list (kername * string * bool * nat * posit
   let '(_, pr_env, cenv, ctag, itag, nenv, fenv, _, prog) := t in
   let '(p, str) := LambdaANF_to_Clight_stack.compile
                      argsIdent allocIdent nallocIdent limitIdent gcIdent mainIdent bodyIdent threadInfIdent
-                     tinfIdent heapInfIdent numArgsIdent isptrIdent caseIdent
+                     tinfIdent heapInfIdent numArgsIdent isptrIdent caseIdent resultIdent
                      args
                      pr_env
                      stackframeTIdent frameIdent rootIdent fpIdent nextFld rootIdent prevFld


### PR DESCRIPTION
Includes some styling in `theories/Codegen/LambdaANF_to_Clight_stack.v` too. 

Hopefully this PR won't break a lot in the backend correctness proof for the ANF backend, but I'd be surprised if it did.

The CPS backend shouldn't be affected by this.