### PR TITLE
Update metacoq

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,8 +19,8 @@ jobs:
         opam_file:
           - 'coq-certicoq.opam'
         image:
-          # - 'mattam82/coq:8.17--ocaml-4.13.1--clang-11--compcert-3.12--extlib-0.11.8--equations-1.3' # comment back in if MetaCoq commit changes
-          - 'yforster/coq:8.17.0--clang-11--compcert-3.12--extlib-0.11.8--equations-1.3--elpi.1.17.1-metacoq-8.17.dev.e0794e3'
+          - 'mattam82/coq:8.17--ocaml-4.13.1--clang-11--compcert-3.12--extlib-0.11.8--equations-1.3' # comment back in if MetaCoq commit changes
+          # - 'yforster/coq:8.17.0--clang-11--compcert-3.12--extlib-0.11.8--equations-1.3--elpi.1.17.1-metacoq-8.17.dev.e0794e3'
       fail-fast: false  # don't stop jobs if one fails
     steps:
       - uses: actions/checkout@v2
@@ -30,13 +30,13 @@ jobs:
         with:
           custom_image: ${{ matrix.image }}
           opam_file: ${{ matrix.opam_file }}
-          # before_install: | # comment back in if MetaCoq commit changes
-          #   startGroup "fix permission issues"
-          #     sudo chown -R coq:coq .
-          #   endGroup
-          #   startGroup "opam pin"
-          #     opam pin -n -y submodules/metacoq
-          #   endGroup
+          before_install: | # comment back in if MetaCoq commit changes
+            startGroup "fix permission issues"
+              sudo chown -R coq:coq .
+            endGroup
+            startGroup "opam pin"
+              opam pin -n -y submodules/metacoq
+            endGroup
           before_script: |
             startGroup "fix permission issues"
               sudo chown -R coq:coq .

--- a/bootstrap/certicoqc/certicoqc_plugin_wrapper.ml
+++ b/bootstrap/certicoqc/certicoqc_plugin_wrapper.ml
@@ -41,7 +41,7 @@ let fix_set u =
   block
 
 let fix_universe u =
-  let open Universe in
+  let open Universes0.Sort in
   let proof_obj = Obj.magic 1 in
   let fix_ues ues : Obj.t = 
     let block = Obj.new_block 0 2 in
@@ -57,9 +57,9 @@ let fix_universe u =
     block
   in
   match u with 
-  | Coq_lProp -> Coq_lProp
-  | Coq_lSProp -> Coq_lSProp
-  | Coq_lType neues -> Coq_lType (Obj.magic (fix_neues neues))
+  | Coq_sProp -> Coq_sProp
+  | Coq_sSProp -> Coq_sSProp
+  | Coq_sType neues -> Coq_sType (Obj.magic (fix_neues neues))
 
 let fix_term (p : Ast0.term) : Ast0.term =
   let open List in
@@ -79,6 +79,7 @@ let fix_term (p : Ast0.term) : Ast0.term =
   | Coq_tCoFix (mfix, i) -> Coq_tCoFix (map aux_def mfix, i)
   | Coq_tInt i -> Coq_tInt i
   | Coq_tFloat f -> Coq_tFloat f
+  | Coq_tArray (u, v, def, ty) -> Coq_tArray (u, map aux v, aux def, aux ty)
   and aux_pred { puinst = puinst; pparams = pparams; pcontext = pcontext; preturn = preturn } =
     { puinst; pparams = map aux pparams; pcontext; preturn = aux preturn }
   and aux_branch { bcontext = bcontext; bbody = bbody } =

--- a/bootstrap/certicoqchk/certicoqchk_plugin_wrapper.ml
+++ b/bootstrap/certicoqchk/certicoqchk_plugin_wrapper.ml
@@ -41,7 +41,7 @@ let fix_set u =
   block
 
 let fix_universe u =
-  let open Universe in
+  let open Sort in
   let proof_obj = Obj.magic 1 in
   let fix_ues ues : Obj.t = 
     let block = Obj.new_block 0 2 in
@@ -57,9 +57,9 @@ let fix_universe u =
     block
   in
   match u with 
-  | Coq_lProp -> Coq_lProp
-  | Coq_lSProp -> Coq_lSProp
-  | Coq_lType neues -> Coq_lType (Obj.magic (fix_neues neues))
+  | Coq_sProp -> Coq_sProp
+  | Coq_sSProp -> Coq_sSProp
+  | Coq_sType neues -> Coq_sType (Obj.magic (fix_neues neues))
 
 let fix_term (p : Ast0.term) : Ast0.term =
   let open List in
@@ -77,6 +77,7 @@ let fix_term (p : Ast0.term) : Ast0.term =
   | Coq_tProj (p, t) -> Coq_tProj (p, aux t)
   | Coq_tFix (mfix, i) -> Coq_tFix (map aux_def mfix, i)
   | Coq_tCoFix (mfix, i) -> Coq_tCoFix (map aux_def mfix, i)
+  | Coq_tArray (u, v, def, ty) -> Coq_tArray (u, map aux v, aux def, aux ty)
   and aux_pred { puinst = puinst; pparams = pparams; pcontext = pcontext; preturn = preturn } =
     { puinst; pparams = map aux pparams; pcontext; preturn = aux preturn }
   and aux_branch { bcontext = bcontext; bbody = bbody } =

--- a/cplugin/_CoqProject
+++ b/cplugin/_CoqProject
@@ -169,12 +169,16 @@ extraction/decimal.ml
 extraction/decimal.mli
 extraction/transform.mli
 extraction/transform.ml
+extraction/ePrimitive.mli
+extraction/ePrimitive.ml
 extraction/eAst.ml
 extraction/eAst.mli
 extraction/eAstUtils.ml
 extraction/eAstUtils.mli
 extraction/eEnvMap.mli
 extraction/eEnvMap.ml
+extraction/eGlobalEnv.mli
+extraction/eGlobalEnv.ml
 # extraction/eLiftSubst.mli
 # extraction/eLiftSubst.ml
 extraction/eCSubst.ml
@@ -211,6 +215,12 @@ extraction/equalities.ml
 extraction/equalities.mli
 extraction/erasureFunction.ml
 extraction/erasureFunction.mli
+extraction/erasureFunctionProperties.mli
+extraction/erasureFunctionProperties.ml
+extraction/optimizePropDiscr.mli
+extraction/optimizePropDiscr.ml
+extraction/extractionCorrectness.mli
+extraction/extractionCorrectness.ml
 extraction/erasure.ml
 extraction/erasure.mli
 extraction/errors0.ml

--- a/cplugin/certicoq.ml
+++ b/cplugin/certicoq.ml
@@ -27,7 +27,7 @@ let fix_set u =
   block
 
 let fix_universe u =
-  let open Universes0.Universe in
+  let open Universes0.Sort in
   let fix_ues ues : Obj.t = 
     let block = Obj.new_block 0 1 in
     Obj.set_field block 0 (Obj.magic ues);
@@ -40,9 +40,9 @@ let fix_universe u =
     block
   in
   match u with 
-  | Coq_lProp -> Coq_lProp
-  | Coq_lSProp -> Coq_lSProp
-  | Coq_lType neues -> Coq_lType (Obj.magic (fix_neues neues))
+  | Coq_sProp -> Coq_sProp
+  | Coq_sSProp -> Coq_sSProp
+  | Coq_sType neues -> Coq_sType (Obj.magic (fix_neues neues))
 
 let fix_term (p : Ast0.term) : Ast0.term =
   let open Ast0 in
@@ -64,6 +64,7 @@ let fix_term (p : Ast0.term) : Ast0.term =
   | Coq_tCoFix (mfix, i) -> Coq_tCoFix (map aux_def mfix, i)
   | Coq_tInt i -> p
   | Coq_tFloat f -> p
+  | Coq_tArray (u, v, def, ty) -> Coq_tArray (u, map aux v, aux def, aux ty)
   and aux_pred { puinst = puinst; pparams = pparams; pcontext = pcontext; preturn = preturn } =
     { puinst; pparams = map aux pparams; pcontext; preturn = aux preturn }
   and aux_branch { bcontext = bcontext; bbody = bbody } =

--- a/cplugin/certicoq_vanilla_plugin.mlpack
+++ b/cplugin/certicoq_vanilla_plugin.mlpack
@@ -118,6 +118,7 @@ Ssrbool
 WGraph
 UGraph0
 Typing0
+PCUICPrimitive
 PCUICAst
 PCUICAstUtils
 PCUICCases
@@ -135,7 +136,6 @@ PCUICProgram
 PCUICExpandLets
 TemplateToPCUIC
 PCUICTransform
-PCUICPrimitive
 PCUICErrors
 PCUICEqualityDec
 PCUICWfEnv
@@ -148,18 +148,23 @@ PCUICSafeChecker
 PCUICSafeRetyping
 SafeTemplateChecker
 
+EPrimitive
 EAst
 EAstUtils
 EInduction
 ECSubst
 EWellformed
 EEnvMap
+EGlobalEnv
 EWcbvEval
 ESpineView
 EPretty
 Extract
 EEtaExpanded
 ErasureFunction
+ErasureFunctionProperties
+OptimizePropDiscr
+ExtractionCorrectness
 EProgram
 ERemoveParams
 EOptimizePropDiscr

--- a/plugin/_CoqProject
+++ b/plugin/_CoqProject
@@ -162,8 +162,12 @@ extraction/decimal.ml
 extraction/decimal.mli
 extraction/transform.mli
 extraction/transform.ml
+extraction/ePrimitive.mli
+extraction/ePrimitive.ml
 extraction/eAst.ml
 extraction/eAst.mli
+extraction/eGlobalEnv.mli
+extraction/eGlobalEnv.ml
 extraction/eAstUtils.ml
 extraction/eAstUtils.mli
 extraction/eEnvMap.mli
@@ -204,6 +208,12 @@ extraction/equalities.ml
 extraction/equalities.mli
 extraction/erasureFunction.ml
 extraction/erasureFunction.mli
+extraction/erasureFunctionProperties.mli
+extraction/erasureFunctionProperties.ml
+extraction/optimizePropDiscr.mli
+extraction/optimizePropDiscr.ml
+extraction/extractionCorrectness.mli
+extraction/extractionCorrectness.ml
 extraction/erasure.ml
 extraction/erasure.mli
 extraction/errors0.ml

--- a/plugin/certicoq_plugin.mlpack
+++ b/plugin/certicoq_plugin.mlpack
@@ -113,8 +113,8 @@ Ssrbool
 WGraph
 UGraph0
 Typing0
-PCUICAst
 PCUICPrimitive
+PCUICAst
 PCUICAstUtils
 PCUICCases
 PCUICUnivSubst
@@ -146,18 +146,21 @@ PCUICSafeChecker
 PCUICSafeRetyping
 SafeTemplateChecker
 
+EPrimitive
 EAst
 EAstUtils
 EInduction
 ECSubst
 EWellformed
 EEnvMap
+EGlobalEnv
 EWcbvEval
 ESpineView
 EPretty
 Extract
 EEtaExpanded
 ErasureFunction
+ErasureFunctionProperties
 EProgram
 ERemoveParams
 EOptimizePropDiscr
@@ -165,6 +168,8 @@ EInlineProjections
 EConstructorsAsBlocks
 ETransform
 Erasure
+OptimizePropDiscr
+ErasureCorrectness
 SafeTemplateErasure
 
 ZArith_dec

--- a/theories/Codegen/LambdaANF_to_Clight.v
+++ b/theories/Codegen/LambdaANF_to_Clight.v
@@ -708,7 +708,9 @@ Program Definition to_float (f : PrimFloat.float) : Floats.float :=
 Next Obligation.
   unfold model_to_ff.
   pose proof (FloatAxioms.Prim2SF_valid f).
-  rewrite Binary.valid_binary_SF2FF; auto.
+  rewrite Binary.valid_binary_SF2FF. exact H.
+  unfold float64_to_model. 
+  unfold FloatOps.Prim2SF. cbn.
   Admitted.
 
 Definition compile_float (cenv : ctor_env) (ienv : n_ind_env) (fenv : fun_env) (map : fun_info_env)
@@ -721,8 +723,8 @@ Definition compile_float (cenv : ctor_env) (ienv : n_ind_env) (fenv : fun_env) (
 
 Definition compile_primitive (cenv : ctor_env) (ienv : n_ind_env) (fenv : fun_env) (map : fun_info_env) (x : positive) (p : AstCommon.primitive) : statement :=
   match projT1 p as tag return AstCommon.prim_value tag -> statement with
-  | Primitive.primInt => fun i => x ::= Econst_long (to_int64 i) (Tlong Unsigned noattr)
-  | Primitive.primFloat => fun f => compile_float cenv ienv fenv map x (to_float f)
+  | AstCommon.primInt => fun i => x ::= Econst_long (to_int64 i) (Tlong Unsigned noattr)
+  | AstCommon.primFloat => fun f => compile_float cenv ienv fenv map x (to_float f)
   end (projT2 p).
 
 Fixpoint translate_body

--- a/theories/Codegen/LambdaANF_to_Clight_stack.v
+++ b/theories/Codegen/LambdaANF_to_Clight_stack.v
@@ -799,8 +799,8 @@ Definition compile_float (cenv : ctor_env) (ienv : n_ind_env) (fenv : fun_env) (
 
 Definition compile_primitive (cenv : ctor_env) (ienv : n_ind_env) (fenv : fun_env) (map : fun_info_env) (x : positive) (p : AstCommon.primitive) : statement :=
   match projT1 p as tag return AstCommon.prim_value tag -> statement with
-  | Primitive.primInt => fun i => x ::= Econst_long (to_int64 i) (Tlong Unsigned noattr)
-  | Primitive.primFloat => fun f => compile_float cenv ienv fenv map x (to_float f)
+  | AstCommon.primInt => fun i => x ::= Econst_long (to_int64 i) (Tlong Unsigned noattr)
+  | AstCommon.primFloat => fun f => compile_float cenv ienv fenv map x (to_float f)
   end (projT2 p).
 
 Section Translation.

--- a/theories/Glue/glue.v
+++ b/theories/Glue/glue.v
@@ -527,7 +527,7 @@ Section L1Types.
         match e with
           | Ast.tProd _ _ e' => check_last e'
           | Ast.tSort u =>
-              MetaCoq.Common.Universes.Universe.is_prop u
+              MetaCoq.Common.Universes.Sort.is_prop u
           | _ => false
         end
     in check_last (Ast.Env.ind_type (ty_body info)).

--- a/theories/LambdaANF/PrototypeGenFrame.v
+++ b/theories/LambdaANF/PrototypeGenFrame.v
@@ -576,7 +576,7 @@ Definition nAnon := {| binder_name := nAnon; binder_relevance := Relevant |}.
 Definition nNamed n := {| binder_name := nNamed n; binder_relevance := Relevant |}.
 
 Definition fn : term -> term -> term := tProd nAnon.
-Definition type0 := tSort Universe.type0.
+Definition type0 := tSort Sort.type0.
 Definition func x t e := tLambda (nNamed x) t e.
 Definition lam t e := tLambda nAnon t e.
 

--- a/theories/LambdaANF/cps_proto.v
+++ b/theories/LambdaANF/cps_proto.v
@@ -236,13 +236,13 @@ Class Iso A B := {
 Notation "'![' e ']'" := (isoBofA e).
 Notation "'[' e ']!'" := (isoAofB e).
 
-Instance Iso_exp_c_exp_ctx : Iso (exp_c exp_univ_exp exp_univ_exp) exp_ctx := {
+#[global] Instance Iso_exp_c_exp_ctx : Iso (exp_c exp_univ_exp exp_univ_exp) exp_ctx := {
   isoAofB := c_of_exp_ctx;
   isoBofA := exp_ctx_of_c;
   isoABA := c_exp_ctx_c;
   isoBAB := exp_ctx_c_exp_ctx }.
 
-Instance Iso_fundefs_c_fundefs_ctx : Iso (exp_c exp_univ_exp exp_univ_fundefs) fundefs_ctx := {
+#[global] Instance Iso_fundefs_c_fundefs_ctx : Iso (exp_c exp_univ_exp exp_univ_fundefs) fundefs_ctx := {
   isoAofB := c_of_fundefs_ctx;
   isoBofA := fundefs_ctx_of_c;
   isoABA := c_fundefs_ctx_c;
@@ -552,7 +552,7 @@ Class Inhabited A := inhabitant : A.
 Import PrimInt63.
 
 Global Instance Inhabited_primitive : Inhabited AstCommon.primitive := 
-  { inhabitant := existT _ Primitive.primInt 0%uint63 }.  
+  { inhabitant := existT _ AstCommon.primInt 0%uint63 }.  
 
 Definition univ_inhabitant {A} : univD A :=
   match A with

--- a/theories/LambdaANF/cps_show.v
+++ b/theories/LambdaANF/cps_show.v
@@ -3,7 +3,6 @@
     [show_exp e] constructs a string representing the term that has some
     minimal formatting so that it's much more readable.
 *)
-Require Import Common.AstCommon.
 Require Import List.
 Require Import LambdaANF.cps.
 Require Import ExtLib.Data.Positive.
@@ -13,6 +12,7 @@ Require Import ExtLib.Data.Monads.StateMonad.
 From MetaCoq.Utils Require Import bytestring MCString. (* For identifier names *)
 From MetaCoq.Common Require Import BasicAst Primitive. (* For identifier names *)
 From MetaCoq.PCUIC Require Import PCUICPrimitive. (* For identifier names *)
+Require Import Common.AstCommon.
 
 Import MonadNotation.
 
@@ -110,6 +110,7 @@ Definition emit_prim (p : primitive) : M unit :=
   match projT1 p as tag return prim_value tag -> M unit with
   | primInt => fun f => emit "(int: " ;; emit (string_of_prim_int f) ;; emit ")"
   | primFloat => fun f => emit "(float: " ;; emit (string_of_float f) ;; emit ")"
+  
   end%bs (projT2 p).
 
 (* We assume each expression starts on a fresh newline, and that it

--- a/theories/LambdaBoxMut/compile.v
+++ b/theories/LambdaBoxMut/compile.v
@@ -336,7 +336,7 @@ Fixpoint list_Defs (l : list (def Term)) : Defs :=
   | t :: ts => dcons t.(dname) t.(dbody) t.(rarg) (list_Defs ts) 
   end.
 
-Equations trans_prim_val {T} (p : EPrimitive.prim_val T) : option primitive :=
+Polymorphic Equations trans_prim_val {T} (p : EPrimitive.prim_val T) : option primitive :=
   trans_prim_val (existT _ primInt (primIntModel i)) => Some (existT _ AstCommon.primInt i) ;
   trans_prim_val (existT _ primFloat (primFloatModel i)) => Some (existT _ AstCommon.primFloat i) ;
   trans_prim_val (existT _ primArray _) => None.

--- a/theories/LambdaBoxMut/compile.v
+++ b/theories/LambdaBoxMut/compile.v
@@ -13,8 +13,7 @@ From MetaCoq.Utils Require utils.
 From MetaCoq.Template Require EtaExpand.
 From MetaCoq.Utils Require Import bytestring.
 From MetaCoq.Common Require Import Primitive.
-From MetaCoq.PCUIC Require Import PCUICPrimitive.
-From MetaCoq.Erasure Require Import EAst ESpineView EGlobalEnv EEtaExpanded EInduction Erasure.
+From MetaCoq.Erasure Require Import EPrimitive EAst ESpineView EGlobalEnv EEtaExpanded EInduction Erasure.
 From MetaCoq.ErasurePlugin Require Import Erasure.
 
 Local Open Scope bs_scope.
@@ -336,15 +335,11 @@ Fixpoint list_Defs (l : list (def Term)) : Defs :=
   | [] => dnil
   | t :: ts => dcons t.(dname) t.(dbody) t.(rarg) (list_Defs ts) 
   end.
-  
-Definition trans_prim_model {T} {t : prim_tag} (e : @prim_model T t) : prim_value t :=
-  match e in @prim_model _ x return prim_value x with
-  | primIntModel i => i
-  | primFloatModel f => f
-  end.
 
-Definition trans_prim_val {T} (p : prim_val T) : primitive :=
-  existT _ (projT1 p) (trans_prim_model (projT2 p)).
+Equations trans_prim_val {T} (p : EPrimitive.prim_val T) : option primitive :=
+  trans_prim_val (existT _ primInt (primIntModel i)) => Some (existT _ AstCommon.primInt i) ;
+  trans_prim_val (existT _ primFloat (primFloatModel i)) => Some (existT _ AstCommon.primFloat i) ;
+  trans_prim_val (existT _ primArray _) => None.
 
 Section Compile.
   Import MCList (map_InP, In_size).
@@ -372,7 +367,9 @@ Section Compile.
       TFix (list_Defs mfix') idx
     | tProj p bod := TWrong "Proj"; (* Impossible, no projections at this stage *)
     | tCoFix mfix idx => TWrong "TCofix"
-    | tPrim p => TPrim (trans_prim_val p)
+    | tPrim p with trans_prim_val p := 
+      { | None => TWrong "unsupported primtive type"
+        | Some pv => TPrim pv }
     | tVar _ => TWrong "Var"
     | tEvar _ _ => TWrong "Evar" }.
   Proof.

--- a/theories/LambdaBoxMut/stripEvalCommute.v
+++ b/theories/LambdaBoxMut/stripEvalCommute.v
@@ -84,9 +84,11 @@ Lemma Lookup_hom :
 Proof.
   induction Σ; cbn => //.
   intros s ec.
+  Admitted.
+  (*
   case: eqb_specT.
   - intros -> ? [= <-].
-    exists g. split. now exists [a].
+    exists g. split. red. now exists [a].
     now depelim s.
     destruct a as [kn d]; cbn.
     now rewrite eqb_refl.
@@ -97,7 +99,7 @@ Proof.
     destruct ext as [Σ'' ->]. now exists (a :: Σ'').
     destruct a as [kn d']; cbn.
     cbn in neq; case: eqb_specT => //.
-Qed.
+Qed.*)
   
 Lemma lookup_hom_None:
   forall nm,
@@ -165,9 +167,9 @@ Lemma wellformed_lookup_constructor_pars {Σ kn c mdecl idecl cdecl} :
   wf_glob Σ ->
   lookup_constructor Σ kn c = Some (mdecl, idecl, cdecl) -> mdecl.(ind_npars) = 0.
 Proof.
-  intros wf. cbn -[lookup_minductive].
-  destruct lookup_minductive eqn:hl => //.
-  do 2 destruct nth_error => //.
+  intros wf. unfold lookup_constructor, lookup_inductive.
+  destruct lookup_minductive eqn:hl => //=. 
+  do 2 destruct nth_error => //=.
   eapply wellformed_lookup_inductive_pars in hl => //. congruence.
 Qed.
 
@@ -176,7 +178,7 @@ Lemma lookup_constructor_pars_args_spec {Σ ind n mdecl idecl cdecl} :
   lookup_constructor Σ ind n = Some (mdecl, idecl, cdecl) ->
   lookup_constructor_pars_args Σ ind n = Some (mdecl.(ind_npars), cdecl.(cstr_nargs)).
 Proof.
-  cbn -[lookup_constructor] => wfΣ.
+  cbn -[lookup_constructor] => wfΣ. unfold lookup_constructor_pars_args.
   destruct lookup_constructor as [[[mdecl' idecl'] [pars args]]|] eqn:hl => //.
   intros [= -> -> <-]. cbn. f_equal.
 Qed.
@@ -200,7 +202,7 @@ Proof.
   intros hwf.
   rewrite /constructor_isprop_pars_decl /lookup_constructor /lookup_inductive.
   destruct lookup_minductive as [mdecl|] eqn:hl => /= //.
-  do 2 destruct nth_error => //.
+  do 2 destruct nth_error => //=.
   eapply wellformed_lookup_inductive_pars in hl => //. congruence.
 Qed.
 
@@ -460,9 +462,9 @@ Lemma compile_crctInd {Σ ind mdecl idecl} :
 Proof.
   move=> wfΣ.
   unfold lookup_inductive, lookup_minductive.
-  destruct lookup_env eqn:hl => /= //.
+  destruct lookup_env eqn:hl => /= //=.
   eapply lookup_env_lookup in hl => //.
-  destruct g => //.
+  destruct g => //=.
   destruct nth_error eqn:hnth => //.
   intros [= <- <-]. econstructor. red.
   split. eapply lookup_Lookup. cbn. rewrite hl //.
@@ -539,6 +541,7 @@ Proof.
     constructor; eauto.
     now eapply compile_isLambda.
   - cbn. rewrite -dlength_hom. move/andP: H0 => [] /Nat.ltb_lt //.
+  - destruct p as [? []]; try constructor; eauto. simp trans_prim_val. cbn. cbn in H. constructor.
 Qed.
 
 Lemma compile_fresh kn Σ : fresh_global kn Σ -> fresh kn (compile_ctx Σ).

--- a/theories/LambdaBoxMut/stripEvalCommute.v
+++ b/theories/LambdaBoxMut/stripEvalCommute.v
@@ -93,22 +93,23 @@ Lemma Lookup_hom :
 Proof.
   induction Σ; cbn => //.
   intros s ec.
-  Admitted.
-  (*
   case: eqb_specT.
   - intros -> ? [= <-].
-    exists g. split. red. now exists [a].
-    now depelim s.
+    exists g. split. red. intros kn d hl. cbn. depelim s. cbn.
+    case: eqb_specT. intros ->. now eapply lookup_env_Some_fresh in hl. auto. now depelim s.
     destruct a as [kn d]; cbn.
     now rewrite eqb_refl.
   - intros neq d hl.
     forward IHg. now depelim s.
     destruct (IHg _ _ hl) as [Σ' [ext hl']].
     exists Σ'. split => //.
-    destruct ext as [Σ'' ->]. now exists (a :: Σ'').
-    destruct a as [kn d']; cbn.
-    cbn in neq; case: eqb_specT => //.
-Qed.*)
+    + intros kn d' hl''; cbn.
+      case: eqb_specT.
+      * intros ->. destruct a as [kn' ?]; cbn in *. eapply ext in hl''.  depelim s. now eapply lookup_env_Some_fresh in hl''.
+      * intros hkn. now eapply ext in hl''.
+    + destruct a as [kn d']; cbn.
+      cbn in neq; case: eqb_specT => //.
+Qed.
   
 Lemma lookup_hom_None:
   forall nm,

--- a/theories/common/AstCommon.v
+++ b/theories/common/AstCommon.v
@@ -74,8 +74,8 @@ Proof.
 Defined.
 
 Require Import NArith.NArith.
-Instance NEq: Eq N := { eq_dec := N.eq_dec }.
-Instance EqPair A B `(Eq A) `(Eq B) : Eq (A * B).
+#[global] Instance NEq: Eq N := { eq_dec := N.eq_dec }.
+#[global] Instance EqPair A B `(Eq A) `(Eq B) : Eq (A * B).
 Proof.
   constructor; intros [x y] [x' y'].
   destruct (eq_dec x x'). destruct (eq_dec y y').
@@ -84,7 +84,7 @@ Proof.
   right; congruence.
 Defined.
 
-Instance InductiveEq: Eq inductive := { eq_dec := inductive_dec }.
+#[global] Instance InductiveEq: Eq inductive := { eq_dec := inductive_dec }.
 
 
 (** certiCoq representation of inductive types **)
@@ -557,8 +557,12 @@ Proof. reflexivity. Qed.
 (* Primitives *)
 
 From Coq Require Import ssreflect.
-From MetaCoq.Common Require Import Primitive.
 From Equations Require Import Equations.
+From MetaCoq.Erasure Require Import EPrimitive.
+
+Variant prim_tag : Set := 
+  | primInt | primFloat. 
+Derive NoConfusion for prim_tag.
 
 Definition prim_value (p : prim_tag) : Set :=
  match p with


### PR DESCRIPTION
Primitive arrays are now supported in LambdaBox, but we don't treat them yet in CertiCoq, we just use flags to ensure that correctness of compilation/evaluation still holds on array-free terms.