### PR TITLE
Define anf_trans using anf_state to help typeclass resolution

### DIFF
--- a/theories/LambdaANF/toplevel.v
+++ b/theories/LambdaANF/toplevel.v
@@ -137,12 +137,12 @@ Section IDENT.
     }.
 
 
-  Definition anf_trans : Type := exp -> comp_data -> error exp * comp_data. 
-
-
   Definition anf_state (A : Type) := comp_data -> error A * comp_data.
 
   
+  Definition anf_trans : Type := exp -> anf_state exp.
+
+
   Global Instance MonadState : Monad anf_state :=
     { ret A x := (fun c_data  => (Ret x, c_data));
       bind A B m f :=


### PR DESCRIPTION
I am trying to make coq-ext-lib classes stricter to resolve, to reduce the likelihood of infinite loops. This patch makes certicoq compatible with this coq-ext-lib PR: https://github.com/coq-community/coq-ext-lib/pull/126