### PR TITLE
Fix deprecations

### DIFF
--- a/.vscode/CertiCoq.code-workspace
+++ b/.vscode/CertiCoq.code-workspace
@@ -5,6 +5,7 @@
 		}
 	],
 	"settings": {
-		"coqtop.binPath": "_opam/bin"
+		"coqtop.binPath": "_opam/bin",
+		"coqtop.args": []
 	}
 }

--- a/theories/Codegen/LambdaANF_to_Clight_correct.v
+++ b/theories/Codegen/LambdaANF_to_Clight_correct.v
@@ -1255,7 +1255,7 @@ Definition prefix_ctx {A:Type} rho' rho :=
    destruct z. inv H0. destruct z.
    - inv H0. 
    - rewrite <- Nat.div2_div in H0. simpl in H0. rewrite Nat.div2_div in H0. 
-     apply lt_S_n in H0.
+     apply Nat.succ_lt_mono in H0.
      assert (Hz := NPeano.Nat.lt_decidable 1 z). inv Hz.
      specialize (IHn _ H1 H0). omega.
      destruct z.
@@ -3638,8 +3638,8 @@ Definition traceless_step2:  genv -> state -> state -> Prop := fun ge s s' => st
 
 Definition m_tstep2 (ge:genv):=  clos_trans state (traceless_step2 ge).
 
-Hint Unfold Ptrofs.modulus Ptrofs.max_unsigned uint_range : core.
-Hint Transparent Ptrofs.max_unsigned Ptrofs.modulus uint_range : core.
+#[global] Hint Unfold Ptrofs.modulus Ptrofs.max_unsigned uint_range : core.
+#[global] Hint Transparent Ptrofs.max_unsigned Ptrofs.modulus uint_range : core.
  
 Inductive mem_after_n_proj_store_rev: block -> Z -> (list Values.val) -> mem -> mem -> Prop :=
 | Mem_last_ind: forall m b ofs v m', 

--- a/theories/LambdaANF/Ensembles_util.v
+++ b/theories/LambdaANF/Ensembles_util.v
@@ -12,10 +12,10 @@ Close Scope Z_scope.
 
 Ltac inv H := inversion H; clear H;  subst.
 
-Hint Constructors Singleton : core.
-Hint Constructors Union : core.
-Hint Constructors Intersection : core.
-Hint Unfold In : core.
+#[global] Hint Constructors Singleton : core.
+#[global] Hint Constructors Union : core.
+#[global] Hint Constructors Intersection : core.
+#[global] Hint Unfold In : core.
 
 Create HintDb Ensembles_DB.
 
@@ -73,7 +73,7 @@ Proof.
   eapply H2. eapply H1; eauto.
 Qed.
 
-Instance PreOrder_Included {A} : PreOrder (@Included A).
+#[global] Instance PreOrder_Included {A} : PreOrder (@Included A).
 Proof.
   constructor. 
   now apply Included_refl.
@@ -101,7 +101,7 @@ Proof.
   intros [H1 H2] [H3 H4]. split; eapply Included_trans; eauto.
 Qed.
 
-Instance Equivalence_Same_set {A} : Equivalence (@Same_set A).
+#[global] Instance Equivalence_Same_set {A} : Equivalence (@Same_set A).
 Proof.
   constructor. 
   now apply Same_set_refl.
@@ -109,7 +109,7 @@ Proof.
   intros ? ? ? ? ?. now eapply Same_set_trans; eauto.
 Qed.
 
-Hint Immediate Same_set_refl Included_refl : Ensembles_DB.
+#[global] Hint Immediate Same_set_refl Included_refl : Ensembles_DB.
 
 Ltac edb := eauto with Ensembles_DB.
 
@@ -118,7 +118,7 @@ Ltac edb := eauto with Ensembles_DB.
 Class Decidable {A} (S : Ensemble A) : Type :=
  { Dec : forall x, { S x } + {~ S x} }.
 
-Instance Decidable_Union {A} (S1 S2 : Ensemble A)
+#[global] Instance Decidable_Union {A} (S1 S2 : Ensemble A)
          {H1 : Decidable S1} {H2 : Decidable S2} : Decidable (Union A S1 S2).
 Proof.
   constructor. intros x.
@@ -127,7 +127,7 @@ Proof.
   right. intros Hun. inv Hun; eauto.
 Qed.
 
-Instance Decidable_Intersection {A} (S1 S2 : Ensemble A)
+#[global] Instance Decidable_Intersection {A} (S1 S2 : Ensemble A)
          {H1 : Decidable S1} {H2 : Decidable S2} : Decidable (Intersection A S1 S2).
 Proof.
   constructor. intros x.
@@ -135,7 +135,7 @@ Proof.
   try (now left; constructor); right; intros Hc; inv Hc; eauto.
 Qed.
 
-Instance Decidable_Setminus {A} s1 s2 { H1 : Decidable s1 }
+#[global] Instance Decidable_Setminus {A} s1 s2 { H1 : Decidable s1 }
          { H2 : Decidable s2 } : Decidable (Setminus A s1 s2).
 Proof.
   constructor. intros x. destruct H1, H2. destruct (Dec1 x).
@@ -145,7 +145,7 @@ Proof.
 Qed.
 
 (** $\{x\}$ is decidable. TODO : generalize the type *)
-Instance DecidableSingleton_positive x : Decidable (Singleton positive x).
+#[global] Instance DecidableSingleton_positive x : Decidable (Singleton positive x).
 Proof.
   constructor. intros x'.
   destruct (peq x x'); subst. left; constructor.
@@ -167,14 +167,14 @@ Qed.
 
 (** * Proper instances *)
 
-Instance Proper_Union_l A :
+#[global] Instance Proper_Union_l A :
   Proper (Same_set A ==> Logic.eq ==> Same_set A)
          (Union A).
 Proof.
   constructor; subst; intros x' H'; destruct H'; destruct H as [H1 H2]; eauto.
 Qed.
 
-Instance Proper_Union_r A :
+#[global] Instance Proper_Union_r A :
   Proper (Logic.eq ==> Same_set A ==> Same_set A)
          (Union A).
 Proof.
@@ -183,7 +183,7 @@ Qed.
 
 
 
-Instance Proper_Setminus_l A :
+#[global] Instance Proper_Setminus_l A :
   Proper (Same_set A ==> Logic.eq ==> Same_set A)
          (Setminus A).
 Proof.
@@ -191,7 +191,7 @@ Proof.
   inv H'; constructor; eauto.
 Qed.
 
-Instance Proper_Setminus_r A :
+#[global] Instance Proper_Setminus_r A :
   Proper (Logic.eq ==> Same_set A ==> Same_set A)
          (Setminus A).
 Proof.
@@ -199,21 +199,21 @@ Proof.
   inv H'; constructor; eauto.
 Qed.
 
-Instance Proper_Intersection_l A :
+#[global] Instance Proper_Intersection_l A :
   Proper (Same_set A ==> Logic.eq ==> Same_set A)
          (Intersection A).
 Proof.
   constructor; subst; intros x' H'; destruct H'; constructor; firstorder.
 Qed.
 
-Instance Proper_Intersection_r A :
+#[global] Instance Proper_Intersection_r A :
   Proper (Logic.eq ==> Same_set A ==> Same_set A)
          (Intersection A).
 Proof.
   constructor; subst; intros x' H'; destruct H'; constructor; firstorder.
 Qed.
 
-Instance Proper_Disjoint_l A :
+#[global] Instance Proper_Disjoint_l A :
   Proper (Same_set A ==> Logic.eq ==> iff)
          (Disjoint A).
 Proof.
@@ -221,7 +221,7 @@ Proof.
   constructor; intros x' HIn; inv HIn; eapply H; constructor; eauto.
 Qed.
 
-Instance Proper_Disjoint_r A :
+#[global] Instance Proper_Disjoint_r A :
   Proper (Logic.eq ==> Same_set A ==> iff)
          (Disjoint A).
 Proof.
@@ -229,13 +229,13 @@ Proof.
   constructor; intros x' HIn; inv HIn; eapply H; constructor; eauto.
 Qed.
 
-Instance Proper_In {A} :
+#[global] Instance Proper_In {A} :
   Proper (Same_set A ==> Logic.eq ==> iff) (Ensembles.In A).
 Proof.
   constructor; intros H'; subst; destruct H as [H1 H2]; eauto.
 Qed.
 
-Instance Proper_Included_l A :
+#[global] Instance Proper_Included_l A :
   Proper (Same_set A ==> Logic.eq ==> iff)
          (Included A).
 Proof.
@@ -243,7 +243,7 @@ Proof.
   intros x' HIn; eauto.
 Qed.
 
-Instance Proper_Included_r A :
+#[global] Instance Proper_Included_r A :
   Proper (Logic.eq ==> Same_set A ==> iff)
          (Included A).
 Proof.
@@ -251,7 +251,7 @@ Proof.
   intros x' HIn; eauto.
 Qed.
 
-Instance Proper_Same_set_l A :
+#[global] Instance Proper_Same_set_l A :
   Proper (Same_set A ==> Logic.eq ==> iff)
          (Same_set A).
 Proof.
@@ -259,7 +259,7 @@ Proof.
   constructor; eauto; eapply Included_trans; eauto.
 Qed.
 
-Instance Proper_Same_set_r A :
+#[global] Instance Proper_Same_set_r A :
   Proper (Logic.eq ==> Same_set A ==> iff)
          (Same_set A).
 Proof.
@@ -267,7 +267,7 @@ Proof.
   constructor; eauto; eapply Included_trans; eauto.
 Qed.
 
-Instance Complement_Proper {A : Type} : Proper (Same_set A ==> Same_set A) (Complement A). 
+#[global] Instance Complement_Proper {A : Type} : Proper (Same_set A ==> Same_set A) (Complement A). 
 Proof.
   intros s1 s2 [Hin1 Hin2]; split; intros x Hc Hc'; eapply Hc; eauto.
 Qed.
@@ -296,7 +296,7 @@ Proof.
   eapply H0; eauto.
 Qed.
 
-Hint Immediate Union_commut Intersection_commut : Ensembles_DB.
+#[global] Hint Immediate Union_commut Intersection_commut : Ensembles_DB.
 
 (** ** Associativity properties *)
 
@@ -316,7 +316,7 @@ Proof.
   inv H. now eauto.
 Qed.
 
-Hint Immediate Union_assoc Intersection_assoc : Ensembles_DB.
+#[global] Hint Immediate Union_assoc Intersection_assoc : Ensembles_DB.
 
 (** ** Distributitvity properties *)
 
@@ -383,7 +383,7 @@ Proof.
 Qed.
 
 
-Hint Immediate Setminus_Union_distr Union_Intersection_distr : Ensembles_DB.
+#[global] Hint Immediate Setminus_Union_distr Union_Intersection_distr : Ensembles_DB.
 
 (** ** Compatibility properties *)
 
@@ -431,7 +431,7 @@ Proof.
 Qed.     
 
 
-Hint Resolve Included_Union_compat Same_set_Union_compat
+#[global] Hint Resolve Included_Union_compat Same_set_Union_compat
      Included_Setminus_compat Same_set_Setminus_compat : Ensembles_DB.
 
 (** ** [Empty_set] is neutral *)
@@ -455,7 +455,7 @@ Proof.
   constructor; eauto. intros H'; inv H'.
 Qed.
 
-Hint Immediate Union_Empty_set_neut_r Union_Empty_set_neut_l
+#[global] Hint Immediate Union_Empty_set_neut_r Union_Empty_set_neut_l
      Setminus_Empty_set_neut_r : Ensembles_DB.
 
 (** ** [Empty_set] is absorbing *)
@@ -478,7 +478,7 @@ Proof.
   split; intros x H; inv H; eauto.
 Qed.
 
-Hint Immediate Intersection_Empty_set_abs_r Intersection_Empty_set_abs_l
+#[global] Hint Immediate Intersection_Empty_set_abs_r Intersection_Empty_set_abs_l
      Setminus_Empty_set_abs_r  : Ensembles_DB.
 
 (** ** Idemptotency properties *)
@@ -497,7 +497,7 @@ Proof.
   inv H; eauto.
 Qed.
 
-Hint Immediate Union_idempotent Intersection_idempotent : Ensembles_DB.
+#[global] Hint Immediate Union_idempotent Intersection_idempotent : Ensembles_DB.
 
 (** ** De Morgan's laws *)
 
@@ -532,7 +532,7 @@ Proof.
   inv H; intros Hc; inv Hc; eauto.
 Qed.
 
-Hint Immediate Union_DeMorgan : Ensembles_DB.
+#[global] Hint Immediate Union_DeMorgan : Ensembles_DB.
 
 (** ** Complement is involutive *)
 
@@ -550,7 +550,7 @@ Proof.
   exfalso; eauto.
 Qed.
 
-Hint Immediate Complement_involutive_l : Ensembles_DB.
+#[global] Hint Immediate Complement_involutive_l : Ensembles_DB.
 
 (** ** Inclusion properties *)
 
@@ -663,9 +663,9 @@ Proof.
   left; constructor; eauto.
 Qed.
 
-Hint Immediate Included_Empty_set Included_Union_l Included_Union_r
+#[global] Hint Immediate Included_Empty_set Included_Union_l Included_Union_r
      Setminus_Included : Ensembles_DB.
-Hint Resolve Included_Union_preserv_l Included_Union_preserv_r Setminus_Included_preserv
+#[global] Hint Resolve Included_Union_preserv_l Included_Union_preserv_r Setminus_Included_preserv
      Setminus_Included_Included_Union Union_Included Singleton_Included
      Included_Setminus Included_Union_Setminus_Included_Union : Ensembles_DB.
 
@@ -840,11 +840,11 @@ Proof.
 Qed.
 
 
-Hint Resolve Disjoint_Setminus_l Disjoint_Setminus_r Union_Disjoint_l
+#[global] Hint Resolve Disjoint_Setminus_l Disjoint_Setminus_r Union_Disjoint_l
      Union_Disjoint_r Disjoint_Singleton_l Disjoint_Singleton_r
      Setminus_Disjoint_preserv_l Setminus_Disjoint_preserv_r  : Ensembles_DB.
 
-Hint Immediate Disjoint_Empty_set_l Disjoint_Empty_set_r : Ensembles_DB.
+#[global] Hint Immediate Disjoint_Empty_set_l Disjoint_Empty_set_r : Ensembles_DB.
 
 (** ** Set difference properties *)
 
@@ -1001,8 +1001,8 @@ Proof.
   inv Hsuff.
 Qed.
 
-Hint Immediate Setminus_Same_set_Empty_set Setminus_Union : Ensembles_DB.
-Hint Resolve  Setminus_Disjoint Setminus_Included_Empty_set
+#[global] Hint Immediate Setminus_Same_set_Empty_set Setminus_Union : Ensembles_DB.
+#[global] Hint Resolve  Setminus_Disjoint Setminus_Included_Empty_set
      Setminus_Union_Included Included_Setminus_Disjoint : Ensembles_DB.
 
 (** ** Other properties *)
@@ -1087,8 +1087,8 @@ Proof.
   intros Hin x Hin' y. eauto.
 Qed.
 
-Hint Immediate not_In_Empty_set : Ensembles_DB.
-Hint Resolve  Included_Empty_set_l Included_Empty_set_r Complement_antimon
+#[global] Hint Immediate not_In_Empty_set : Ensembles_DB.
+#[global] Hint Resolve  Included_Empty_set_l Included_Empty_set_r Complement_antimon
      Complement_Disjoint : Ensembles_DB.
 
 (** ** Big union *)
@@ -1188,7 +1188,7 @@ Proof.
   - inv H'. inv H0. eexists; split; eauto. apply H; eauto.
 Qed.
 
-Instance Proper_big_cup {A B} : Proper (Same_set A ==> eq ==> Same_set B) big_cup.
+#[global] Instance Proper_big_cup {A B} : Proper (Same_set A ==> eq ==> Same_set B) big_cup.
 Proof.
   intros ? ? ? ? ? ?; subst. now apply Same_Set_big_cup_l.
 Qed.
@@ -1226,9 +1226,9 @@ Proof.
       split; eauto. constructor.
 Qed.
 
-Hint Immediate Union_big_cup Setminus_big_cup big_cup_Singleton
+#[global] Hint Immediate Union_big_cup Setminus_big_cup big_cup_Singleton
      big_cup_Empty_set: Ensembles_DB.
-Hint Resolve Included_big_cup_l Same_Set_big_cup_l : Ensembles_DB.
+#[global] Hint Resolve Included_big_cup_l Same_Set_big_cup_l : Ensembles_DB.
 
 (** * List of sets union *)
 
@@ -1245,7 +1245,7 @@ Definition FromList {A} (l : list A) : Ensemble A :=
   fun x => List.In x l.
 
 (* TODO : generalize the type *)
-Instance Decidable_FromList (l : list positive) : Decidable (FromList l). 
+#[global] Instance Decidable_FromList (l : list positive) : Decidable (FromList l). 
 Proof. 
   constructor. intros x. induction l. 
   - right. intros H. inv H. 
@@ -1335,7 +1335,7 @@ Proof.
       eapply Singleton_Included. eauto.
 Qed.
 
-Instance Decidable_FromList_gen A (H : forall (x y : A), {x = y} + {x <> y}) (l : list A) :
+#[global] Instance Decidable_FromList_gen A (H : forall (x y : A), {x = y} + {x <> y}) (l : list A) :
   Decidable (FromList l).
 Proof.
   constructor. intros x. induction l. 
@@ -1347,7 +1347,7 @@ Proof.
 Qed.
 
 (* TODO move *)
-Instance Decidable_map_UnionList {A B : Type} (f : A -> Ensemble B) (H : forall x, Decidable (f x)) l :
+#[global] Instance Decidable_map_UnionList {A B : Type} (f : A -> Ensemble B) (H : forall x, Decidable (f x)) l :
   Decidable (Union_list (map f l)).
 Proof.
   induction l; constructor.
@@ -1385,278 +1385,278 @@ Proof.
 Qed.
 
 
-Hint Immediate FromList_nil FromList_cons FromList_app
+#[global] Hint Immediate FromList_nil FromList_cons FromList_app
      FromList_singleton : Ensembles_DB.
 
-Hint Extern 1 (Same_set _
+#[global] Hint Extern 1 (Same_set _
                         (Union _ ?A (Union _ ?B ?C))
                         (Union _ ?B (Union _ ?A ?D))) =>
 rewrite (Union_assoc A B C), (Union_assoc B A D), (Union_commut A B) : Ensembles_DB.
 
-Hint Extern 1 (Same_set _
+#[global] Hint Extern 1 (Same_set _
                         (Union _ ?A (Union _ ?B ?C))
                         (Union _ (Union _ ?B ?A) ?D)) =>
 rewrite (Union_assoc A B C), (Union_commut A B) : Ensembles_DB.
 
-Hint Extern 1 (Same_set _
+#[global] Hint Extern 1 (Same_set _
                         (Union _ (Union _ ?B ?A) ?D)
                         (Union _ ?A (Union _ ?B ?C))) =>
 rewrite (Union_assoc A B C), (Union_commut A B) : Ensembles_DB.
 
-Hint Extern 1 (Included _
+#[global] Hint Extern 1 (Included _
                         (Union _ ?A (Union _ ?B ?C))
                         (Union _ ?B (Union _ ?A ?D))) =>
 rewrite (Union_assoc A B C), (Union_assoc B A D), (Union_commut A B) : Ensembles_DB.
 
-Hint Extern 1 (Included _
+#[global] Hint Extern 1 (Included _
                         (Union _ ?A (Union _ ?B ?C))
                         (Union _ (Union _ ?B ?A) ?D)) =>
 rewrite (Union_assoc A B C), (Union_commut A B) : Ensembles_DB.
 
-Hint Extern 1 (Included _
+#[global] Hint Extern 1 (Included _
                         (Union _ (Union _ ?B ?A) ?D)
                         (Union _ ?A (Union _ ?B ?C))) =>
 rewrite (Union_assoc A B C), (Union_commut A B) : Ensembles_DB.
 
 
 
-Hint Extern 1 (Same_set _ _ (Union _ (Union _ ?A ?A) ?C)) =>
+#[global] Hint Extern 1 (Same_set _ _ (Union _ (Union _ ?A ?A) ?C)) =>
 rewrite (Union_Same_set A A); [| now apply Included_refl ] : Ensembles_DB.
 
-Hint Extern 1 (Same_set _ (Union _ (Union _ ?A ?A) ?C) _) =>
+#[global] Hint Extern 1 (Same_set _ (Union _ (Union _ ?A ?A) ?C) _) =>
 rewrite (Union_Same_set A A);  [| now apply Included_refl ] : Ensembles_DB.
 
-Hint Extern 1 (Same_set _ _ (Union _ ?A (Union _ ?A ?C))) =>
+#[global] Hint Extern 1 (Same_set _ _ (Union _ ?A (Union _ ?A ?C))) =>
 rewrite (Union_assoc A A C), (Union_Same_set A A);
   [| now apply Included_refl ] : Ensembles_DB.
 
-Hint Extern 1 (Same_set _ (Union _ ?A (Union _ ?A ?C)) _) =>
+#[global] Hint Extern 1 (Same_set _ (Union _ ?A (Union _ ?A ?C)) _) =>
 rewrite (Union_assoc A A C), (Union_Same_set A A);
   [| now apply Included_refl ] : Ensembles_DB.
 
-Hint Extern 1 (Included _ _ (Union _ (Union _ ?A ?A) ?C)) =>
+#[global] Hint Extern 1 (Included _ _ (Union _ (Union _ ?A ?A) ?C)) =>
 rewrite (Union_Same_set A A); [| now apply Included_refl ] : Ensembles_DB.
 
-Hint Extern 1 (Included _ (Union _ (Union _ ?A ?A) ?C) _) =>
+#[global] Hint Extern 1 (Included _ (Union _ (Union _ ?A ?A) ?C) _) =>
 rewrite (Union_Same_set A A);  [| now apply Included_refl ] : Ensembles_DB.
 
-Hint Extern 1 (Included _ _ (Union _ ?A (Union _ ?A ?C))) =>
+#[global] Hint Extern 1 (Included _ _ (Union _ ?A (Union _ ?A ?C))) =>
 rewrite (Union_assoc A A C), (Union_Same_set A A);
   [| now apply Included_refl ] : Ensembles_DB.
 
-Hint Extern 1 (Included _ (Union _ ?A (Union _ ?A ?C)) _) =>
+#[global] Hint Extern 1 (Included _ (Union _ ?A (Union _ ?A ?C)) _) =>
 rewrite (Union_assoc A A C), (Union_Same_set A A);
   [| now apply Included_refl ] : Ensembles_DB.
 
-Hint Extern 1 (Disjoint _ _ (Union _ (Union _ ?A ?A) ?C)) =>
+#[global] Hint Extern 1 (Disjoint _ _ (Union _ (Union _ ?A ?A) ?C)) =>
 rewrite (Union_Same_set A A); [| now apply Included_refl ] : Ensembles_DB.
 
-Hint Extern 1 (Disjoint _ (Union _ (Union _ ?A ?A) ?C) _) =>
+#[global] Hint Extern 1 (Disjoint _ (Union _ (Union _ ?A ?A) ?C) _) =>
 rewrite (Union_Same_set A A);  [| now apply Included_refl ] : Ensembles_DB.
 
-Hint Extern 1 (Disjoint _ _ (Union _ ?A (Union _ ?A ?C))) =>
+#[global] Hint Extern 1 (Disjoint _ _ (Union _ ?A (Union _ ?A ?C))) =>
 rewrite (Union_assoc A A C), (Union_Same_set A A);
   [| now apply Included_refl ] : Ensembles_DB.
 
-Hint Extern 1 (Disjoint _ (Union _ ?A (Union _ ?A ?C)) _) =>
+#[global] Hint Extern 1 (Disjoint _ (Union _ ?A (Union _ ?A ?C)) _) =>
 rewrite (Union_assoc A A C), (Union_Same_set A A);
   [| now apply Included_refl ] : Ensembles_DB.
 
 
-Hint Extern 1 (Same_set _
+#[global] Hint Extern 1 (Same_set _
                         (Setminus _ _ (Union _ _ _))
                         (Setminus _ (Setminus _ _ _) _)) =>
 rewrite Setminus_Union : Ensembles_DB.
 
-Hint Extern 1 (Same_set _
+#[global] Hint Extern 1 (Same_set _
                         (Setminus _ (Setminus _ _ _) _)
                         (Setminus _ _ (Union _ _ _))) =>
 rewrite Setminus_Union : Ensembles_DB.
 
-Hint Extern 1 (Same_set _
+#[global] Hint Extern 1 (Same_set _
                         (Setminus _ (Union _ _ _) _)
                         (Union _ (Setminus _ _ ?A) (Setminus _ _ ?A))) =>
 rewrite Setminus_Union_distr : Ensembles_DB.
 
-Hint Extern 1 (Same_set _
+#[global] Hint Extern 1 (Same_set _
                         (Union _ (Setminus _ _ ?A) (Setminus _ _ ?A))
                         (Setminus _ (Union _ _ _) _)) =>
 rewrite Setminus_Union_distr : Ensembles_DB.
 
-Hint Extern 1 (Included _
+#[global] Hint Extern 1 (Included _
                         (Setminus _ _ (Union _ _ _))
                         (Setminus _ (Setminus _ _ _) _)) =>
 rewrite Setminus_Union : Ensembles_DB.
 
-Hint Extern 1 (Included _
+#[global] Hint Extern 1 (Included _
                         (Setminus _ (Setminus _ _ _) _)
                         (Setminus _ _ (Union _ _ _))) =>
 rewrite Setminus_Union : Ensembles_DB.
 
-Hint Extern 1 (Included _
+#[global] Hint Extern 1 (Included _
                         (Setminus _ (Union _ _ _) _)
                         (Union _ (Setminus _ _ ?A) (Setminus _ _ ?A))) =>
 rewrite Setminus_Union_distr : Ensembles_DB.
 
-Hint Extern 1 (Included _
+#[global] Hint Extern 1 (Included _
                         (Union _ (Setminus _ _ ?A) (Setminus _ _ ?A))
                         (Setminus _ (Union _ _ _) _)) =>
 rewrite Setminus_Union_distr : Ensembles_DB.
 
 
-Hint Extern 1 (Same_set _ (Union _ (Empty_set _) _) _) =>
+#[global] Hint Extern 1 (Same_set _ (Union _ (Empty_set _) _) _) =>
 rewrite Union_Empty_set_neut_l : Ensembles_DB.
 
-Hint Extern 1 (Included _ (Union _ (Empty_set _) _) _) =>
+#[global] Hint Extern 1 (Included _ (Union _ (Empty_set _) _) _) =>
 rewrite Union_Empty_set_neut_l :  Ensembles_DB.
 
-Hint Extern 1 (Disjoint _ (Union _ (Empty_set _) _) _) =>
+#[global] Hint Extern 1 (Disjoint _ (Union _ (Empty_set _) _) _) =>
 rewrite Union_Empty_set_neut_l : Ensembles_DB.
 
-Hint Extern 1 (Same_set _ (Union _ _ (Empty_set _)) _) =>
+#[global] Hint Extern 1 (Same_set _ (Union _ _ (Empty_set _)) _) =>
 rewrite Union_Empty_set_neut_r : Ensembles_DB.
 
-Hint Extern 1 (Included _ (Union _ _ (Empty_set _)) _) =>
+#[global] Hint Extern 1 (Included _ (Union _ _ (Empty_set _)) _) =>
 rewrite Union_Empty_set_neut_r : Ensembles_DB.
 
-Hint Extern 1 (Disjoint _ (Union _ _ (Empty_set _)) _) =>
+#[global] Hint Extern 1 (Disjoint _ (Union _ _ (Empty_set _)) _) =>
 rewrite Union_Empty_set_neut_r : Ensembles_DB.
 
-Hint Extern 1 (Same_set _ _ (Union _ (Empty_set _) _)) =>
+#[global] Hint Extern 1 (Same_set _ _ (Union _ (Empty_set _) _)) =>
 rewrite Union_Empty_set_neut_l : Ensembles_DB.
 
-Hint Extern 1 (Included _ _ (Union _ (Empty_set _) _)) =>
+#[global] Hint Extern 1 (Included _ _ (Union _ (Empty_set _) _)) =>
 rewrite Union_Empty_set_neut_l :  Ensembles_DB.
 
-Hint Extern 1 (Disjoint _ _ (Union _ (Empty_set _) _)) =>
+#[global] Hint Extern 1 (Disjoint _ _ (Union _ (Empty_set _) _)) =>
 rewrite Union_Empty_set_neut_l : Ensembles_DB.
 
-Hint Extern 1 (Same_set _ _ (Union _ _ (Empty_set _))) =>
+#[global] Hint Extern 1 (Same_set _ _ (Union _ _ (Empty_set _))) =>
 rewrite Union_Empty_set_neut_r : Ensembles_DB.
 
-Hint Extern 1 (Included _ _ (Union _ _ (Empty_set _))) =>
+#[global] Hint Extern 1 (Included _ _ (Union _ _ (Empty_set _))) =>
 rewrite Union_Empty_set_neut_r : Ensembles_DB.
 
-Hint Extern 1 (Disjoint _ _ (Union _ _ (Empty_set _))) =>
+#[global] Hint Extern 1 (Disjoint _ _ (Union _ _ (Empty_set _))) =>
 rewrite Union_Empty_set_neut_r : Ensembles_DB.
 
 
-Hint Extern 1 (Same_set _
+#[global] Hint Extern 1 (Same_set _
                         (Union _ ?A (Union _ ?B ?C))
                         (Union _ ?D (Union _ ?A ?E))) =>
 rewrite (Union_assoc A B C), (Union_assoc D A E), (Union_commut D A),
 <- (Union_assoc A B C), <- (Union_assoc A D E) : Ensembles_DB.
 
-Hint Extern 1 (Same_set _
+#[global] Hint Extern 1 (Same_set _
                         (Union _ ?D (Union _ ?A ?E))
                         (Union _ ?A (Union _ ?B ?C))) =>
 rewrite (Union_assoc A B C), (Union_assoc D A E), (Union_commut D A),
 <- (Union_assoc A B C), <- (Union_assoc A D E) : Ensembles_DB.
 
-Hint Extern 1 (Same_set _
+#[global] Hint Extern 1 (Same_set _
                         (Union _ ?A (Union _ ?B ?C))
                         (Union _ ?D (Union _ ?E ?A))) =>
 rewrite (Union_assoc A B C), (Union_assoc D E A), (Union_commut (Union _ D E) A),
 <- (Union_assoc A B C) : Ensembles_DB.
 
-Hint Extern 1 (Same_set _
+#[global] Hint Extern 1 (Same_set _
                         (Union _ ?D (Union _ ?E ?A))
                         (Union _ ?A (Union _ ?B ?C))) =>
 rewrite (Union_assoc A B C), (Union_assoc D E A), (Union_commut (Union _ D E) A),
 <- (Union_assoc A B C) : Ensembles_DB.
 
 
-Hint Extern 1 (Same_set _
+#[global] Hint Extern 1 (Same_set _
                         (Union _ ?A (Union _ ?B ?C))
                         (Union _ (Union _ ?D ?A) ?E)) =>
 rewrite (Union_assoc A B C), (Union_commut D A),
 <- (Union_assoc A B C), <- (Union_assoc A D E) : Ensembles_DB.
 
 
-Hint Extern 1 (Same_set _
+#[global] Hint Extern 1 (Same_set _
                         (Union _ (Union _ ?D ?A) ?E)
                         (Union _ ?A (Union _ ?B ?C))) =>
 rewrite (Union_assoc A B C), (Union_commut D A),
 <- (Union_assoc A B C), <- (Union_assoc A D E) : Ensembles_DB.
 
-Hint Extern 1 (Same_set _
+#[global] Hint Extern 1 (Same_set _
                         (Union _ ?A ?B)
                         (Union _ ?C ?A)) =>
 rewrite (Union_commut C A) : Ensembles_DB.
 
-Hint Extern 1 (Same_set _
+#[global] Hint Extern 1 (Same_set _
                         (Union _ ?C ?A)
                         (Union _ ?A ?B)) =>
 rewrite (Union_commut C A) : Ensembles_DB.
 
-Hint Extern 1 (Included _
+#[global] Hint Extern 1 (Included _
                         (Union _ ?A (Union _ ?B ?C))
                         (Union _ ?D (Union _ ?A ?E))) =>
 rewrite (Union_assoc A B C), (Union_assoc D A E), (Union_commut D A),
 <- (Union_assoc A B C), <- (Union_assoc A D E) : Ensembles_DB.
 
-Hint Extern 1 (Included _
+#[global] Hint Extern 1 (Included _
                         (Union _ ?D (Union _ ?A ?E))
                         (Union _ ?A (Union _ ?B ?C))) =>
 rewrite (Union_assoc A B C), (Union_assoc D A E), (Union_commut D A),
 <- (Union_assoc A B C), <- (Union_assoc A D E) : Ensembles_DB.
 
-Hint Extern 1 (Included _
+#[global] Hint Extern 1 (Included _
                         (Union _ ?A (Union _ ?B ?C))
                         (Union _ ?D (Union _ ?E ?A))) =>
 rewrite (Union_assoc A B C), (Union_assoc D E A), (Union_commut (Union _ D E) A),
 <- (Union_assoc A B C) : Ensembles_DB.
 
-Hint Extern 1 (Included _
+#[global] Hint Extern 1 (Included _
                         (Union _ ?D (Union _ ?E ?A))
                         (Union _ ?A (Union _ ?B ?C))) =>
 rewrite (Union_assoc A B C), (Union_assoc D E A), (Union_commut (Union _ D E) A),
 <- (Union_assoc A B C) : Ensembles_DB.
 
 
-Hint Extern 1 (Included _
+#[global] Hint Extern 1 (Included _
                         (Union _ ?A (Union _ ?B ?C))
                         (Union _ (Union _ ?D ?A) ?E)) =>
 rewrite (Union_assoc A B C), (Union_commut D A),
 <- (Union_assoc A B C), <- (Union_assoc A D E) : Ensembles_DB.
 
 
-Hint Extern 1 (Included _
+#[global] Hint Extern 1 (Included _
                         (Union _ (Union _ ?D ?A) ?E)
                         (Union _ ?A (Union _ ?B ?C))) =>
 rewrite (Union_assoc A B C), (Union_commut D A),
 <- (Union_assoc A B C), <- (Union_assoc A D E) : Ensembles_DB.
 
-Hint Extern 1 (Included _
+#[global] Hint Extern 1 (Included _
                         (Union _ ?A ?B)
                         (Union _ ?C ?A)) =>
 rewrite (Union_commut C A) : Ensembles_DB.
 
-Hint Extern 1 (Included _
+#[global] Hint Extern 1 (Included _
                         (Union _ ?C ?A)
                         (Union _ ?A ?B)) =>
 rewrite (Union_commut C A) : Ensembles_DB.
 
-Hint Extern 1 (Same_set _ (Union _ ?A (Union _ _ _)) (Union _ (Union _ ?A ?B) ?C)) =>
+#[global] Hint Extern 1 (Same_set _ (Union _ ?A (Union _ _ _)) (Union _ (Union _ ?A ?B) ?C)) =>
 rewrite <- (Union_assoc A B C) : Ensembles_DB.
 
-Hint Extern 1 (Same_set _ (Union _ (Union _ ?A ?B) ?C) (Union _ ?A (Union _ _ _))) =>
+#[global] Hint Extern 1 (Same_set _ (Union _ (Union _ ?A ?B) ?C) (Union _ ?A (Union _ _ _))) =>
 rewrite <- (Union_assoc A B C) : Ensembles_DB.
 
-Hint Extern 1 (Included _ (Union _ ?A (Union _ _ _)) (Union _ (Union _ ?A ?B) ?C)) =>
+#[global] Hint Extern 1 (Included _ (Union _ ?A (Union _ _ _)) (Union _ (Union _ ?A ?B) ?C)) =>
 rewrite <- (Union_assoc A B C) : Ensembles_DB.
 
-Hint Extern 1 (Included _ (Union _ (Union _ ?A ?B) ?C) (Union _ ?A (Union _ _ _))) =>
+#[global] Hint Extern 1 (Included _ (Union _ (Union _ ?A ?B) ?C) (Union _ ?A (Union _ _ _))) =>
 rewrite <- (Union_assoc A B C) : Ensembles_DB.
 
-Hint Extern 5 (Disjoint _ ?A ?B) =>
+#[global] Hint Extern 5 (Disjoint _ ?A ?B) =>
 eapply Disjoint_Included_r; [| eassumption ] : Ensembles_DB.
-Hint Extern 5 (Disjoint _ ?A ?B) =>
+#[global] Hint Extern 5 (Disjoint _ ?A ?B) =>
 eapply Disjoint_Included_l; [| eassumption ] : Ensembles_DB.
 
-Hint Extern 5 (Disjoint _ ?A ?B) =>
+#[global] Hint Extern 5 (Disjoint _ ?A ?B) =>
 eapply Disjoint_Included_r_sym; [| eassumption ] : Ensembles_DB.
-Hint Extern 5 (Disjoint _ ?A ?B) =>
+#[global] Hint Extern 5 (Disjoint _ ?A ?B) =>
 eapply Disjoint_Included_l_sym; [| eassumption ] : Ensembles_DB.
 
 
@@ -1669,23 +1669,23 @@ Definition Proj2 {A B} (S : Ensemble (A * B)) : Ensemble B :=
 Definition Prod {A B} (S : Ensemble A) (S' : Ensemble B) : Ensemble (A * B) :=
   [ set z | let '(x, y) := z in  x \in S /\ y \in S' ].
 
-Instance Proj1_Proper A B : Proper (Same_set (A * B) ==> Same_set A) Proj1.
+#[global] Instance Proj1_Proper A B : Proper (Same_set (A * B) ==> Same_set A) Proj1.
 Proof.
   firstorder.
 Qed. 
 
-Instance Proj2_Proper A B : Proper (Same_set (A * B) ==> Same_set B) Proj2.
+#[global] Instance Proj2_Proper A B : Proper (Same_set (A * B) ==> Same_set B) Proj2.
 Proof.
   firstorder.
 Qed.
 
-Instance Prod_Proper1 A B : Proper (Same_set A ==> eq ==> Same_set (A * B)) Prod.
+#[global] Instance Prod_Proper1 A B : Proper (Same_set A ==> eq ==> Same_set (A * B)) Prod.
 Proof.
   intros s1 s2 Hseq x1 x2 Heq; subst.
   unfold Prod; split; intros [x y]; firstorder.
 Qed. 
 
-Instance Proj_Proper2 A B S : Proper (Same_set B  ==> Same_set (A * B)) (Prod S).
+#[global] Instance Proj_Proper2 A B S : Proper (Same_set B  ==> Same_set (A * B)) (Prod S).
 Proof.
   intros s1 s2 Hseq; subst.
   unfold Prod; split;

--- a/theories/LambdaANF/LambdaBoxLocal_to_LambdaANF_correct.v
+++ b/theories/LambdaANF/LambdaBoxLocal_to_LambdaANF_correct.v
@@ -1036,7 +1036,7 @@ Section Correct.
 
               eapply IHvars with (vs := l). reflexivity. eauto.
               
-              rewrite <- minus_n_O. reflexivity.
+              rewrite Nat.sub_0_r. reflexivity.
               
               rewrite M.gso; eauto. 
               

--- a/theories/LambdaANF/List_util.v
+++ b/theories/LambdaANF/List_util.v
@@ -61,7 +61,7 @@ Inductive Sublist {A : Type} : list A -> list A -> Prop :=
 Definition Subperm {A : Type} (l1 l2 : list A) :=
   exists l2', Sublist l1 l2' /\ Permutation l2' l2. 
 
-Hint Constructors Forall2_asym : core.
+#[global] Hint Constructors Forall2_asym : core.
 
 (** Lemmas about [Forall2] and [Forall2_asym] *)
 Lemma Forall2_length {A B} (R : A -> B -> Prop) l1 l2 :
@@ -700,7 +700,7 @@ Lemma fold_left_extensive {A} f (l : list A) n :
   n <= fold_left f l n.
 Proof.
   revert n; induction l; eauto; intros n H.
-  simpl. eapply le_trans. now eapply H.
+  simpl. eapply Nat.le_trans. now eapply H.
   now eapply IHl.
 Qed.
 
@@ -739,7 +739,7 @@ Proof.
   revert z. induction l; intros z Hin.
   - inv Hin.
   - inv Hin; simpl. 
-    + eapply le_trans; [| now eapply max_list_nat_spec1 ].
+    + eapply Nat.le_trans; [| now eapply max_list_nat_spec1 ].
       eapply Nat.le_max_r.
     + now apply IHl.
 Qed.
@@ -790,15 +790,15 @@ Lemma fold_left_mult { A : Type} (l : list A) (acc1 acc2 : nat) f h :
 Proof.
   revert acc1 acc2. induction l; intros acc1 acc2; simpl.
   - reflexivity.
-  - simpl. eapply le_trans; [| eapply IHl ].
+  - simpl. eapply Nat.le_trans; [| eapply IHl ].
     eapply fold_left_monotonic.
     + intros. lia.
     + rewrite Nat.mul_add_distr_r.
-      eapply plus_le_compat.
-      eapply mult_le_compat_l.
-      eapply Max.le_max_l.
-      eapply mult_le_compat_l.
-      eapply Max.le_max_r.
+      eapply Nat.add_le_mono.
+      eapply Nat.mul_le_mono_l.
+      eapply Nat.le_max_l.
+      eapply Nat.mul_le_mono_l.
+      eapply Nat.le_max_r.
 Qed.
 
 
@@ -867,7 +867,7 @@ Proof.
   eassumption. 
 Qed. 
 
-Instance PermutationA_symm A (eqA : relation A) { _ : Symmetric eqA}
+#[global] Instance PermutationA_symm A (eqA : relation A) { _ : Symmetric eqA}
   : Symmetric (PermutationA eqA).
 Proof.
   intros x1 x2 Hperm. induction Hperm. 

--- a/theories/LambdaANF/MockExpr.v
+++ b/theories/LambdaANF/MockExpr.v
@@ -31,5 +31,5 @@ MetaCoq Run (mk_Frame_ops (MPfile ["MockExpr"; "LambdaANF"; "CertiCoq"])
 (* Print exp_Frame_ops. *)
 (* Print exp_aux_data. *)
 
-Instance Frame_exp : Frame exp_univ := exp_Frame_ops.
-Instance AuxData_exp : AuxData exp_univ := exp_aux_data.
+#[global] Instance Frame_exp : Frame exp_univ := exp_Frame_ops.
+#[global] Instance AuxData_exp : AuxData exp_univ := exp_aux_data.

--- a/theories/LambdaANF/Prototype.v
+++ b/theories/LambdaANF/Prototype.v
@@ -80,7 +80,7 @@ Local Notation "e1 >>= e2" := (ExtLib.Structures.Monad.bind e1 e2).
 Definition set_aname (s : string) (x : aname) :=
   {| binder_name := BasicAst.nNamed s; binder_relevance := x.(binder_relevance) |}.
 
-Instance show_list {A} {s : Show A} : Show (list A) :=
+#[global] Instance show_list {A} {s : Show A} : Show (list A) :=
   { show l := String.concat "," (map show l) }.
 
 Definition lookup (n : nat) (xs : list string) : GM string :=

--- a/theories/LambdaANF/PrototypeTests.v
+++ b/theories/LambdaANF/PrototypeTests.v
@@ -28,7 +28,7 @@ Unset Strict Unquote Universe Mode.
 
 (* ---------- Example ---------- *)
 
-Instance Frame_exp_inj : @Frame_inj exp_univ _.
+#[global] Instance Frame_exp_inj : @Frame_inj exp_univ _.
 Proof. unfold Frame_inj; destruct f; simpl; ltac1:(congruence). Defined.
 
 (* Check frames_nil >:: cons_fundef0 [] >:: fFun2 0%nat []. *)
@@ -61,10 +61,10 @@ Definition used_vars_prop {A : exp_univ} (C : frames_t A exp_univ_exp) (e : univ
 
 (* When just moving up and down, next fresh var doesn't need to be updated *)
 
-Instance Preserves_S_dn_exp : Preserves_S_dn (@used_vars_prop).
+#[global] Instance Preserves_S_dn_exp : Preserves_S_dn (@used_vars_prop).
 Proof. intros A B C C_ok f x; destruct f; unfold used_vars_prop; simpl; intros; assumption. Defined.
 
-Instance Preserves_S_up_exp : Preserves_S_up (@used_vars_prop).
+#[global] Instance Preserves_S_up_exp : Preserves_S_up (@used_vars_prop).
 Proof. intros A B C C_ok f x; destruct f; unfold used_vars_prop; simpl; intros; assumption. Defined.
 
 Extraction Inline Preserves_S_dn_exp Preserves_S_up_exp.
@@ -96,13 +96,13 @@ Definition I_R {A} (C : frames_t A exp_univ_exp) (n : nat) : Prop := C = C.
 
 Definition I_S {A} (C : frames_t A exp_univ_exp) (x : univD A) (n : nat) : Prop := C⟦+x+⟧ = C⟦+x+⟧.
 
-Instance Preserves_R_R_C : Preserves_R (@I_R).
+#[global] Instance Preserves_R_R_C : Preserves_R (@I_R).
 Proof. intros A B C C_ok f [n _]; exists n; unerase; reflexivity. Defined.
 
-Instance Preserves_S_dn_St : Preserves_S_dn (@I_S).
+#[global] Instance Preserves_S_dn_St : Preserves_S_dn (@I_S).
 Proof. intros A B C C_ok f x [n _]; exists n; unerase; reflexivity. Defined.
 
-Instance Preserves_S_up_St : Preserves_S_up (@I_S).
+#[global] Instance Preserves_S_up_St : Preserves_S_up (@I_S).
 Proof. intros A B C C_ok f x [n _]; exists n; unerase; reflexivity. Defined.
 
 Extraction Inline Preserves_R_R_C Preserves_S_dn_St Preserves_S_up_St.
@@ -495,7 +495,7 @@ Compute rw_R'' (xI xH) exp_univ_exp <[]>
 
 (* -------------------- Another example -------------------- *)
 
-Instance Eq_var : Eq var := {rel_dec := fun n m => n ==? m}.
+#[global] Instance Eq_var : Eq var := {rel_dec := fun n m => n ==? m}.
 
 Definition renaming := var -> var.
 
@@ -554,7 +554,7 @@ Proof.
 Defined.
 
 Definition I_renaming A (e : univD A) (d : renaming) : Prop := True.
-Instance Delayed_renaming : Delayed (I_renaming).
+#[global] Instance Delayed_renaming : Delayed (I_renaming).
 Proof.
   ltac1:(unshelve econstructor).
   - destruct A; simpl; intros x [σ _].
@@ -603,7 +603,7 @@ Proof.
   simpl. destruct (PeanoNat.Nat.eqb_spec x y); constructor; ltac1:(congruence).
 Defined.
 
-Instance Preserves_cp_env : Preserves_R (@I_cp_env).
+#[global] Instance Preserves_cp_env : Preserves_R (@I_cp_env).
 Proof.
   unfold I_cp_env; intros A B C C_ok f [ρ Hρ]; destruct f eqn:Heqf;
   ltac1:(
@@ -634,7 +634,7 @@ Proof.
 Defined.
 Extraction Inline Preserves_cp_env.
 
-Instance Eq_constr : Eq constr := {rel_dec := fun n m => n ==? m}.
+#[global] Instance Eq_constr : Eq constr := {rel_dec := fun n m => n ==? m}.
 Lemma eq_constr_spec (x y : constr) : Bool.reflect (x = y) (x ==? y).
 Proof.
   simpl.

--- a/theories/LambdaANF/Rewriting.v
+++ b/theories/LambdaANF/Rewriting.v
@@ -40,11 +40,11 @@ Class e_ok {A} (x : erased A) := erased_ok : exists (y : A), x = (fun k => k y).
 
 (* Erasing a value *)
 Definition erase {A} : A -> erased A := fun x k => k x.
-Instance erase_ok {A} (x : A) : e_ok (erase x). Proof. exists x; reflexivity. Qed.
+#[global] Instance erase_ok {A} (x : A) : e_ok (erase x). Proof. exists x; reflexivity. Qed.
 
 (* Erased values can always be used to construct other erased values *)
 Definition e_map {A B} (f : A -> B) (x : erased A) : erased B := fun k => x (fun x => k (f x)).
-Instance e_map_ok {A B} (f : A -> B) (x : erased A) `{H : e_ok _ x} : e_ok (e_map f x).
+#[global] Instance e_map_ok {A B} (f : A -> B) (x : erased A) `{H : e_ok _ x} : e_ok (e_map f x).
 Proof. destruct H as [y Hy]; subst x; unfold e_map; now exists (f y). Qed.
 
 Definition e_map_fuse {A B C} (f : B -> C) (g : A -> B) (x : erased A) :

--- a/theories/LambdaANF/algebra.v
+++ b/theories/LambdaANF/algebra.v
@@ -109,7 +109,7 @@ Definition exp_ctx_to_fin (C: exp_ctx) : fin :=
 (* Resource indexed by exprssions *)
 
 Class exp_resource {A} :=
-  { HRes :> @resource fin A;
+  { HRes :: @resource fin A;
     one := (fun e => @one_i _ _ HRes (exp_to_fin e));
     one_ctx := (fun C => @one_i _ _ HRes (exp_ctx_to_fin C)) }.
 
@@ -117,15 +117,15 @@ Class exp_resource {A} :=
 (* Fuel resource *)
 
 Class fuel_resource {A} :=
-  { HRexp_f :> @exp_resource A;
-    HOrd    :> @ordered fin A HRes;
-    HOne    :> @resource_ones fin A HRes;
-    HNat    :> @nat_hom fin A HRes
+  { HRexp_f :: @exp_resource A;
+    HOrd    :: @ordered fin A HRes;
+    HOne    :: @resource_ones fin A HRes;
+    HNat    :: @nat_hom fin A HRes
   }.
 
 (* Trace resource *)
 Class trace_resource {A} :=
-  { HRexp_t :> @exp_resource A }.
+  { HRexp_t :: @exp_resource A }.
 
 
 Declare Scope alg_scope.

--- a/theories/LambdaANF/alpha_conv.v
+++ b/theories/LambdaANF/alpha_conv.v
@@ -28,7 +28,7 @@ Fixpoint extend_fundefs (f: var -> var) (B B' : fundefs) : (var -> var) :=
       end
   end.
 
-Instance Proper_extend_fundefs : Proper (f_eq ==> eq ==> eq ==> f_eq) extend_fundefs.
+#[global] Instance Proper_extend_fundefs : Proper (f_eq ==> eq ==> eq ==> f_eq) extend_fundefs.
 Proof.
   intros f1 f2 Hfeq y1 y2 Heq1 x1 x2 Heq2 z1.
   subst. revert x2; induction y2; intros x2; simpl; eauto.
@@ -302,13 +302,13 @@ Proof.
   - inv H'. constructor.
 Qed.
 
-Instance Alpha_conv_proper :
+#[global] Instance Alpha_conv_proper :
   Proper (Logic.eq ==> Logic.eq ==> f_eq ==> iff) Alpha_conv.
 Proof.
   now apply Alpha_conv_proper_mut.
 Qed.
 
-Instance Alpha_conv_fundfes_proper :
+#[global] Instance Alpha_conv_fundfes_proper :
   Proper (Logic.eq ==> Logic.eq ==> f_eq ==> iff) Alpha_conv_fundefs.
 Proof.
   now apply Alpha_conv_proper_mut.
@@ -320,7 +320,7 @@ Definition Alpha_conv_ctx C C' f :=
     Alpha_conv e e' f ->
     Alpha_conv (C |[ e ]|) (C' |[ e']|) f.
 
-Instance alpha_conv_ctx_Proper : Proper (eq ==> eq ==> f_eq ==> iff) Alpha_conv_ctx.
+#[global] Instance alpha_conv_ctx_Proper : Proper (eq ==> eq ==> f_eq ==> iff) Alpha_conv_ctx.
 Proof. 
   intros c1 c2 Heq1 c3 c4 Heq2 f1 f2 Hfeq; subst; split; intros H1 e1 e2 H2.
   rewrite <- Hfeq. rewrite <- Hfeq in H2. now eauto.
@@ -1725,7 +1725,7 @@ Section Alpha_conv_correct.
   
 End Alpha_conv_correct.
 
-Instance preord_env_P_inj_proper' fuel (Hfuel : fuel_resource) trace (Htrace : trace_resource) :
+#[global] Instance preord_env_P_inj_proper' fuel (Hfuel : fuel_resource) trace (Htrace : trace_resource) :
   Proper (Logic.eq ==> Logic.eq ==> Same_set var ==> Logic.eq ==> Logic.eq ==> Logic.eq ==> Logic.eq ==> iff)
          (@preord_env_P_inj fuel Hfuel trace Htrace).
 Proof.
@@ -1735,7 +1735,7 @@ Proof.
 Qed.
 
 
-Instance preord_env_P_inj_f_proper' fuel (Hfuel : fuel_resource) trace (Htrace : trace_resource) :
+#[global] Instance preord_env_P_inj_f_proper' fuel (Hfuel : fuel_resource) trace (Htrace : trace_resource) :
   Proper (Logic.eq ==> Logic.eq ==> Logic.eq ==> Logic.eq ==> f_eq ==> Logic.eq ==> Logic.eq ==> iff)
          (@preord_env_P_inj fuel Hfuel trace Htrace).
 Proof.

--- a/theories/LambdaANF/bounds.v
+++ b/theories/LambdaANF/bounds.v
@@ -151,8 +151,9 @@ Section Bounds.
       
       assert (Hleq' : (1 + 2 * G + 2 * G * 2 * G) * cin1 + 2 * L * 2 * G + 2 * L <=
                       (1 + 2 * G + 2 * G * 2 * G) * cin2 + 2 * L * 2 * G + 2 * L).
-      { eapply Le.le_trans. eassumption. eapply Le.le_trans.
-        eapply plus_le_compat_r. eapply plus_le_compat_l. eapply mult_le_compat_l. eassumption.
+      { eapply Nat.le_trans. eassumption. eapply Nat.le_trans.
+        apply -> Nat.add_le_mono_r. apply -> Nat.add_le_mono_l. 
+        eapply Nat.mul_le_mono_l. eassumption.
         lia. } 
       
       assert (Hleq'' : cin1 <= cin2).
@@ -173,8 +174,10 @@ Section Bounds.
     Proof.
       intros [[[? ?] ?] [? ?]] [[[? ?] ?] [? ?]]. unfold inline_bound, inline_bound_top in *. unfold_all.
       intros. destructAll.
-      eapply le_trans. eassumption.
-      eapply le_trans. eapply plus_le_compat_r. eapply plus_le_compat_l. eapply mult_le_compat_l. eassumption.
+      eapply Nat.le_trans. eassumption.
+      eapply Nat.le_trans. apply -> Nat.add_le_mono_r.
+      apply -> Nat.add_le_mono_l. 
+      eapply Nat.mul_le_mono_l. eassumption.
       lia.
     Qed.
 

--- a/theories/LambdaANF/closure_conversion_correct.v
+++ b/theories/LambdaANF/closure_conversion_correct.v
@@ -565,7 +565,7 @@ Section Closure_conversion_correct.
     n <= n * m.
   Proof.
     rewrite Nat.mul_comm.
-    edestruct mult_O_le; eauto. lia.
+    edestruct Arith_prebase.mult_O_le_stt; eauto. lia.
   Qed.
 
   Lemma plus_le_mult  (a1 a2 b1 b2 b3 : nat) :
@@ -575,13 +575,13 @@ Section Closure_conversion_correct.
     a1 + a2 <= (1 + b1) * a1 * b2.
   Proof.
     intros.
-    rewrite <- mult_assoc, NPeano.Nat.mul_add_distr_r.
-    eapply plus_le_compat.
+    rewrite <- Nat.mul_assoc, NPeano.Nat.mul_add_distr_r.
+    eapply Nat.add_le_mono.
     - simpl. rewrite <- plus_n_O.
       now eapply mult_le_n.
-    - eapply le_trans. eapply le_trans. eassumption.
-      eapply mult_le_compat. eauto. eassumption.
-      rewrite mult_assoc. eapply mult_le_n. eassumption.
+    - eapply Nat.le_trans. eapply Nat.le_trans. eassumption.
+      eapply Nat.mul_le_mono. eauto. eassumption.
+      rewrite Nat.mul_assoc. eapply mult_le_n. eassumption.
   Qed.
 
   
@@ -798,7 +798,7 @@ Section Closure_conversion_correct.
     - (* Case letapp *)
       inv Hcc.
       assert (Hadm : sizeOf_exp_ctx C <= 4 + 4 * length ys).
-      { eapply le_trans. eapply project_vars_sizeOf_ctx_exp; eauto. simpl; lia. }
+      { eapply Nat.le_trans. eapply project_vars_sizeOf_ctx_exp; eauto. simpl; lia. }
       edestruct (HFVs f) as [v' Hgetv]. normalize_occurs_free...
       edestruct (@binding_in_map_get_list val) with (xs := ys) as [vs Hgetvs]; eauto. normalize_occurs_free...
 
@@ -825,8 +825,8 @@ Section Closure_conversion_correct.
         
       eapply ctx_to_rho_cc_approx_exp; eauto.
       eapply cc_approx_exp_letapp_compat with (P1 := boundL 0) (rho1 := rho1) (f1 := f).
-      + eapply HPost_letapp. eapply le_trans. eapply exp_ctx_len_leq_aux. eassumption.
-      + eapply HPost_letapp_OOT. eapply le_trans. eapply exp_ctx_len_leq_aux. eassumption.
+      + eapply HPost_letapp. eapply Nat.le_trans. eapply exp_ctx_len_leq_aux. eassumption.
+      + eapply HPost_letapp_OOT. eapply Nat.le_trans. eapply exp_ctx_len_leq_aux. eassumption.
       + eapply HOOT.
       + rewrite (Union_commut [set f']), <- Union_assoc. intros Hc. inv Hc; eauto. inv H. contradiction.
         revert H. eapply Disjoint_In_l; [| eassumption ]. 
@@ -924,7 +924,7 @@ Section Closure_conversion_correct.
       destruct Ha as [vs Hget_list].
       (* sizes of evaluation contexts *)
       assert (HC1 : sizeOf_exp_ctx C' <= 4 * (length FVs')) by
-          (eapply le_trans; [ now eapply project_vars_sizeOf_ctx_exp; eauto | lia ]).
+          (eapply Nat.le_trans; [ now eapply project_vars_sizeOf_ctx_exp; eauto | lia ]).
 
       edestruct project_vars_ctx_to_rho as [rho2' Hto_rho]; [ | eassumption | | | | | ]; eauto. now sets.
       edestruct project_vars_correct as [Happ [Hfun' [Henv' [Hgfun' Hvar]]]]; eauto. now sets.
@@ -1037,7 +1037,7 @@ Section Closure_conversion_correct.
     - (* Case Eapp *)
       inv Hcc.
       assert(Hadm : sizeOf_exp_ctx C <= 4 * length l + 4)
-        by (eapply le_trans; [ now eapply project_vars_sizeOf_ctx_exp; eauto | simpl; lia ]).
+        by (eapply Nat.le_trans; [ now eapply project_vars_sizeOf_ctx_exp; eauto | simpl; lia ]).
       edestruct HFVs with (x := v) as [v' Hgetv]. normalize_occurs_free...
       edestruct (@binding_in_map_get_list val) with (xs := l) as [vs Hgetvs]; eauto. normalize_occurs_free...
   
@@ -1060,7 +1060,7 @@ Section Closure_conversion_correct.
 
       eapply cc_approx_exp_app_compat.
       + eapply HPost_app.
-        simpl (0 + _). eapply le_trans. eapply exp_ctx_len_leq_aux. rewrite plus_comm. eassumption.
+        simpl (0 + _). eapply Nat.le_trans. eapply exp_ctx_len_leq_aux. rewrite Nat.add_comm. eassumption.
       + eapply HOOT.
       + rewrite (Union_commut [set f']), <- Union_assoc. intros Hc. inv Hc; eauto. inv H. contradiction.
         revert H. eapply Disjoint_In_l; [| eassumption ]. 

--- a/theories/LambdaANF/cps_util.v
+++ b/theories/LambdaANF/cps_util.v
@@ -1333,7 +1333,7 @@ Proof.
   apply num_occur_app_ctx. exists n, 1; auto.
   assert (num_occur (c |[ Ehalt v ]|)  v (m +1)).
   apply num_occur_app_ctx. exists m, 1; auto.
-  eapply plus_reg_l.
+  eapply Nat.add_cancel_l.
   eapply (proj1 (num_occur_det _)).
   rewrite Nat.add_comm.
   apply H2.

--- a/theories/LambdaANF/ctx.v
+++ b/theories/LambdaANF/ctx.v
@@ -63,7 +63,7 @@ with app_f_ctx : fundefs_ctx -> exp -> fundefs -> Prop :=
                     app_f_ctx cfds e cfdse -> 
                     app_f_ctx (Fcons2_c f t ys e' cfds) e (Fcons f t ys e' cfdse).
 
-Hint Constructors app_ctx app_f_ctx : core.
+#[global] Hint Constructors app_ctx app_f_ctx : core.
 
 (** Evaluation context application - Computational definition *)
 Fixpoint app_ctx_f (c:exp_ctx) (e:exp) : exp :=

--- a/theories/LambdaANF/dead_param_elim_util.v
+++ b/theories/LambdaANF/dead_param_elim_util.v
@@ -449,7 +449,7 @@ Proof.
   revert L L' d d'; induction B; simpl; intros L L' d d' Hl; subst.
   - destruct (update_live_fun L v l (live_expr L e PS.empty)) as [L'' b] eqn:Heq.
     destruct b; simpl in *.
-    + eapply le_trans.
+    + eapply Nat.le_trans.
       eapply update_live_fun_size_leq. 
       eassumption.
       eapply IHB. eassumption.
@@ -469,7 +469,7 @@ Proof.
   - destruct (update_live_fun L v l (live_expr L e PS.empty)) as [L'' b] eqn:Heq.
 
     destruct b; simpl in *.
-    + eapply lt_le_trans.
+    + eapply Nat.lt_le_trans.
       eapply update_live_fun_size. eassumption.
       eapply live_size_leq. 
       eassumption.
@@ -639,7 +639,7 @@ Lemma num_vars_acc B m n :
 Proof.
   revert m n. induction B; intros; simpl; eauto.
 
-  rewrite <- plus_assoc. rewrite (plus_comm m). rewrite plus_assoc.
+  rewrite <- Nat.add_assoc. rewrite (Nat.add_comm m). rewrite Nat.add_assoc.
   rewrite IHB. lia.
 Qed. 
   
@@ -713,16 +713,16 @@ Lemma escaping_fun_fundefs_max_size_mut :
       max_map_size (escaping_fun_fundefs B L) <= max_map_size L). 
 Proof.
   exp_defs_induction IHe IHl IHB; simpl; intros; subst; eauto;
-    try (now eapply le_trans; [ eapply IHe | eapply remove_escapings_max_size ]);
-    try (now eapply le_trans; [ eapply IHe | eapply remove_escaping_max_size ]). 
+    try (now eapply Nat.le_trans; [ eapply IHe | eapply remove_escapings_max_size ]);
+    try (now eapply Nat.le_trans; [ eapply IHe | eapply remove_escaping_max_size ]). 
   - simpl in IHl.
-    eapply le_trans. eapply IHl. eapply IHe.
+    eapply Nat.le_trans. eapply IHl. eapply IHe.
   - simpl in *.
-    eapply le_trans. eapply IHe. eapply IHB.
+    eapply Nat.le_trans. eapply IHe. eapply IHB.
   - eapply remove_escapings_max_size.
   - eapply remove_escaping_max_size.
   - simpl in *.
-    eapply le_trans. eapply IHB. eapply IHe.
+    eapply Nat.le_trans. eapply IHB. eapply IHe.
 Qed. 
 
 Lemma escaping_fun_exp_max_size :  

--- a/theories/LambdaANF/functions.v
+++ b/theories/LambdaANF/functions.v
@@ -94,54 +94,54 @@ Definition inverse_subdomain {A B: Type} S (f : A -> B) g :=
 
 (** * Lemmas about [f_eq_subdomain] and [f_eq] *)
 
-Instance equivalence_f_eq_subdomain {A B} S : Equivalence (@f_eq_subdomain A B S). 
+#[global] Instance equivalence_f_eq_subdomain {A B} S : Equivalence (@f_eq_subdomain A B S). 
 Proof. 
   constructor; try now constructor.
   intros f1 f2 Heq x HS; rewrite Heq. reflexivity. eassumption.
   intros f1 f2 f3 Heq1 Heq2 x HS; rewrite Heq1. now eauto. eassumption.
 Qed.
 
-Instance equivalence_f_eq {A B} : Equivalence (@f_eq A B).
+#[global] Instance equivalence_f_eq {A B} : Equivalence (@f_eq A B).
 Proof. 
   constructor; congruence.
 Qed.  
 
-Instance f_eq_subdomain_Proper_Same_set {A B} :
+#[global] Instance f_eq_subdomain_Proper_Same_set {A B} :
   Proper (Same_set A ==> eq ==> eq ==> iff) (@f_eq_subdomain A B).
 Proof.
   intros S1 S2 Hseq f1 f1' Heq1 f2 f2' Heq2; subst; split; intros Hfeq x HS;
   apply Hfeq; eapply Hseq; eassumption.
 Qed.
 
-Instance f_eq_subdomain_Proper_f_eq_l {A B} :
+#[global] Instance f_eq_subdomain_Proper_f_eq_l {A B} :
   Proper (eq ==> f_eq ==> eq ==> iff) (@f_eq_subdomain A B).
 Proof.
   intros S1 S2 Heq f1 f1' Heq1 f2 f2' Heq2; subst; split; intros Hfeq x HS.
   now rewrite <- Heq1; eauto. now rewrite Heq1; eauto.
 Qed.
 
-Instance f_eq_subdomain_Proper_f_eq_r {A B} :
+#[global] Instance f_eq_subdomain_Proper_f_eq_r {A B} :
   Proper (eq ==> eq ==> f_eq ==> iff) (@f_eq_subdomain A B).
 Proof.
   intros S1 S2 Heq f1 f1' Heq1 f2 f2' Heq2; subst; split; intros Hfeq x HS.
   now rewrite <- Heq2; eauto. now rewrite Heq2; eauto.
 Qed.
 
-Instance f_eq_Proper_f_eq_l {A B} :
+#[global] Instance f_eq_Proper_f_eq_l {A B} :
   Proper (f_eq ==> eq ==> iff) (@f_eq A B).
 Proof.
   intros  f1 f1' Heq1 f2 f2' Heq2; subst; split; intros Hfeq x.
   now rewrite <- Heq1; eauto. now rewrite Heq1; eauto.
 Qed.
 
-Instance f_eq_Proper_f_eq_r {A B} :
+#[global] Instance f_eq_Proper_f_eq_r {A B} :
   Proper (eq ==> f_eq ==> iff) (@f_eq A B).
 Proof.
   intros f1 f1' Heq1 f2 f2' Heq2; subst; split; intros Hfeq.
   now rewrite <- Heq2; eauto. now rewrite Heq2; eauto.
 Qed.
 
-Instance map_proper {A B} : Proper (f_eq ==> eq ==> eq) (@map A B).
+#[global] Instance map_proper {A B} : Proper (f_eq ==> eq ==> eq) (@map A B).
 Proof.
   intros f1 f2 Hfeq x1 x2 Heq; subst.
   induction x2; eauto.
@@ -208,13 +208,13 @@ Qed.
 
 (** * Lemmas about [image] *)
 
-Instance image_Proper_Same_set {A B} : Proper (eq ==> Same_set A ==> Same_set B) image.
+#[global] Instance image_Proper_Same_set {A B} : Proper (eq ==> Same_set A ==> Same_set B) image.
 Proof.
   intros x1 x2 Heq1 s1 s2 Hseq; subst; split; intros x [y [Hin Heq]]; subst;
   eexists; split; eauto; apply Hseq; eauto.
 Qed.
 
-Instance image_Proper_f_eq {A B} : Proper (f_eq ==> eq ==> Same_set B) (@image A B).
+#[global] Instance image_Proper_f_eq {A B} : Proper (f_eq ==> eq ==> Same_set B) (@image A B).
 Proof.
   intros x1 x2 Heq1 s1 s2 Hseq2; subst; split; intros x [y [Hin Heq]]; subst;
   eexists; split; eauto; rewrite Heq1; eauto; now (constructor; eauto).
@@ -293,7 +293,7 @@ Qed.
 
 (** * Lemmas about [extend] *)
 
-Instance extend_Proper {A} : Proper (f_eq ==> Logic.eq ==> Logic.eq ==> f_eq) (@extend A).
+#[global] Instance extend_Proper {A} : Proper (f_eq ==> Logic.eq ==> Logic.eq ==> f_eq) (@extend A).
 Proof. 
   intros f1 f2 Hfeq x1 x2 Heq1 x3 x4 Hfeq2; subst.
   intros x. unfold extend. destruct (peq x x2); eauto.
@@ -521,7 +521,7 @@ Proof.
     intros Hc. eapply H0. eapply In_image. eassumption. 
 Qed.
 
-Hint Resolve In_image Included_image_extend : functions_BD.
+#[global] Hint Resolve In_image Included_image_extend : functions_BD.
 
 
 (** * Lemmas about [extend_lst]  *) 
@@ -687,7 +687,7 @@ Proof.
     rewrite map_extend_not_In; eauto.
 Qed.
 
-Instance extend_lst_Proper {A} : Proper (f_eq ==> eq ==> eq ==> f_eq) (@extend_lst A).
+#[global] Instance extend_lst_Proper {A} : Proper (f_eq ==> eq ==> eq ==> f_eq) (@extend_lst A).
 Proof.
   intros f1 f2 f_eq l1 l2 Heq1 l1' l2' Heq2; subst.
   revert l2'. induction l2; simpl; intros l2'; eauto.
@@ -696,21 +696,21 @@ Qed.
 
 (** * Lemmas about [injective_subdomain] and [injective] *)
 
-Instance injective_subdomain_Proper_f_eq {A B} : Proper (eq ==> f_eq ==> iff)
+#[global] Instance injective_subdomain_Proper_f_eq {A B} : Proper (eq ==> f_eq ==> iff)
                                                    (@injective_subdomain A B).
 Proof.
   intros s1 s2 Hseq f1 f2 Hfeq; split; intros Hinj x y Hin1 Hin2 Heq; subst;
   eapply Hinj; eauto. now rewrite !Hfeq. now rewrite <- !Hfeq. 
 Qed.
 
-Instance injective_subdomain_Proper_Same_set {A B} : Proper (Same_set _ ==> eq ==> iff)
+#[global] Instance injective_subdomain_Proper_Same_set {A B} : Proper (Same_set _ ==> eq ==> iff)
                                                    (@injective_subdomain A B).
 Proof.
   intros s1 s2 Hseq f1 f2 Hfeq; split; intros Hinj x y Hin1 Hin2 Heq; subst;
   eapply Hinj; eauto; now apply Hseq.
 Qed.
 
-Instance injective_Proper {A B} : Proper (f_eq ==> iff)
+#[global] Instance injective_Proper {A B} : Proper (f_eq ==> iff)
                                          (@injective A B).
 Proof.
   now apply injective_subdomain_Proper_f_eq. 
@@ -942,7 +942,7 @@ Qed.
 (** * Lemmas about [domain] *)
 
 
-Instance Proper_domain {A B} : Proper (f_eq ==> Same_set A) (@domain A B).
+#[global] Instance Proper_domain {A B} : Proper (f_eq ==> Same_set A) (@domain A B).
 Proof.
   constructor; intros x' [y' H'].
   rewrite H in H'. repeat eexists; eauto.
@@ -990,7 +990,7 @@ Qed.
 
 (** * Lemmas about [image'] *)
 
-Instance Proper_image' {A B} :
+#[global] Instance Proper_image' {A B} :
   Proper (f_eq ==> Same_set _ ==> Same_set B) (@image' A B).
 Proof.
   constructor; intros x' [y' [H1 H2]]; inv H0.
@@ -1152,7 +1152,7 @@ Proof.
     + eexists; split; eauto. rewrite extend_gso; eauto.
 Qed.
 
-Instance Proper_image'_Same_set {A B} :
+#[global] Instance Proper_image'_Same_set {A B} :
   Proper (eq ==> Same_set A ==> Same_set B) image'.
 Proof.
   intros f1 f2 Hfeq s1 s2 Hseq; split; intros x [y [Hin Heq]];
@@ -1179,7 +1179,7 @@ Proof.
   eapply Hinj; eauto.
 Qed.
 
-Instance Proper_injective_subdomain' A B :
+#[global] Instance Proper_injective_subdomain' A B :
   Proper (Same_set A ==> eq ==> iff) (@injective_subdomain' A B).
 Proof.
   intros s1 s2 Hseq f1 f2 Hfeq; subst; split; intros Hinj x y v Hin1 Hin2 Heq1 Heq2;
@@ -1233,12 +1233,12 @@ Proof.
   eexists; split; subst; eauto.
 Qed.  
 
-Instance Proper_compose_l A B C : Proper (f_eq ==> eq ==> f_eq) (@compose A B C).
+#[global] Instance Proper_compose_l A B C : Proper (f_eq ==> eq ==> f_eq) (@compose A B C).
 Proof.
   intros f1 f1' Hfeq f2 f2' Hfeq'; subst; firstorder.
 Qed.
 
-Instance Proper_compose_r A B C : Proper (eq ==> f_eq ==> f_eq) (@compose A B C).
+#[global] Instance Proper_compose_r A B C : Proper (eq ==> f_eq ==> f_eq) (@compose A B C).
 Proof.
   intros f1 f1' Hfeq f2 f2' Hfeq'; subst. intros x; unfold compose; simpl.
   rewrite <- Hfeq'. reflexivity.
@@ -1291,7 +1291,7 @@ Proof.
   eapply image_monotonic; eauto. 
 Qed.       
 
-Instance Proper_inverse_subdomain {A B} : Proper (Same_set A ==> eq ==> eq ==> iff) (@inverse_subdomain A B).
+#[global] Instance Proper_inverse_subdomain {A B} : Proper (Same_set A ==> eq ==> eq ==> iff) (@inverse_subdomain A B).
 Proof. 
   intros s1 s2 Hseq f1 f2 Hfeq g1 g2 Hgeq; subst.
   unfold inverse_subdomain. rewrite Hseq. reflexivity.

--- a/theories/LambdaANF/hoisting.v
+++ b/theories/LambdaANF/hoisting.v
@@ -196,7 +196,7 @@ Proof.
     edestruct split_fds_trans as [B3 [H1 H2]] ; [ apply Hspl1 | |]; eauto.
     repeat eexists. rewrite Heq1, Heq2; eauto.
     constructor. eassumption. 
-    rewrite Max.max_comm. econstructor; eauto. econstructor; eauto.
+    rewrite Nat.max_comm. econstructor; eauto. econstructor; eauto.
     apply split_fds_sym; eauto.
   - repeat eexists; eauto using split_fds_nil_l; repeat econstructor.
 Qed.
@@ -246,7 +246,7 @@ Inductive no_fun_defs : fundefs -> Prop  :=
 | Fnil_no_fun :
     no_fun_defs Fnil.
 
-Hint Constructors no_fun no_fun_defs : core.
+#[global] Hint Constructors no_fun no_fun_defs : core.
 
 Lemma no_fun_split_fds B B' B'' :
   no_fun_defs B -> no_fun_defs B' ->
@@ -750,7 +750,7 @@ Proof.
       -- eassumption.
       -- eassumption.
       -- eassumption.
-      -- eapply le_trans. eassumption. eapply Nat.le_max_r. 
+      -- eapply Nat.le_trans. eassumption. eapply Nat.le_max_r. 
   - inv Hfind.
 Qed.
   

--- a/theories/LambdaANF/identifiers.v
+++ b/theories/LambdaANF/identifiers.v
@@ -37,7 +37,7 @@ Fixpoint fun_in_fundefs  (B : fundefs) : Ensemble (var * fun_tag * list var * ex
   end.
 
 (** The set of function names is decidable *)
-Instance Decidable_name_in_fundefs (B : fundefs) :
+#[global] Instance Decidable_name_in_fundefs (B : fundefs) :
   Decidable (name_in_fundefs B).
 Proof.
   constructor.
@@ -255,7 +255,7 @@ Proof.
     eexists. erewrite def_funs_neq; eauto.
 Qed.
 
-Instance ToMSet_name_in_fundefs B : ToMSet (name_in_fundefs B).
+#[global] Instance ToMSet_name_in_fundefs B : ToMSet (name_in_fundefs B).
 Proof.
   induction B.
   - destruct IHB as [s1 Hseq1].
@@ -352,8 +352,8 @@ with occurs_free_fundefs : fundefs -> Ensemble var :=
       x <> f ->
       occurs_free_fundefs (Fcons f tau ys e defs) x.
 
-Hint Constructors occurs_free : core.
-Hint Constructors occurs_free_fundefs : core.
+#[global] Hint Constructors occurs_free : core.
+#[global] Hint Constructors occurs_free_fundefs : core.
 
 (** [occurs_free_applied e] is the set of free variables of [e] that appear in application position *)
 Inductive occurs_free_applied : exp -> Ensemble var :=
@@ -915,12 +915,12 @@ Qed.
 
 
 (** FV(e) is decidable *)
-Instance Decidable_occurs_free e : Decidable (occurs_free e).
+#[global] Instance Decidable_occurs_free e : Decidable (occurs_free e).
 Proof.
   now apply occurs_free_dec_exp.
 Qed.
 (** FV(B) is decidable *)
-Instance Decidable_occurs_free_fundefs e : Decidable (occurs_free_fundefs e).
+#[global] Instance Decidable_occurs_free_fundefs e : Decidable (occurs_free_fundefs e).
 Proof.
   now apply occurs_free_dec_fundefs.
 Qed.   
@@ -1146,8 +1146,8 @@ with funs_in_fundef : fundefs -> fundefs -> Prop :=
       funs_in_fundef fs fs' ->
       funs_in_fundef fs (Fcons x tau ys e fs').
 
-Hint Constructors funs_in_exp : core.
-Hint Constructors funs_in_fundef : core.
+#[global] Hint Constructors funs_in_exp : core.
+#[global] Hint Constructors funs_in_fundef : core.
 
 Lemma split_fds_funs_in_fundef_l B1 B2 B3 B :
   split_fds B1 B2 B3 ->
@@ -1308,8 +1308,8 @@ with bound_var_fundefs : fundefs -> Ensemble var :=
       bound_var e x ->
       bound_var_fundefs (Fcons f tau ys e defs) x.
 
-Hint Constructors bound_var : core.
-Hint Constructors bound_var_fundefs : core.
+#[global] Hint Constructors bound_var : core.
+#[global] Hint Constructors bound_var_fundefs : core.
 
 (** ** Useful set equalities *)
 
@@ -2849,12 +2849,12 @@ Proof.
     eassumption.
 Qed.
 
-Instance Occurs_free_ToMSet (e : exp) : ToMSet (occurs_free e).
+#[global] Instance Occurs_free_ToMSet (e : exp) : ToMSet (occurs_free e).
 Proof. refine {| mset := exp_fv e |}.
   eapply exp_fv_correct.
 Qed.
 
-Instance Occurs_free_fundefs_ToMSet (B : fundefs) : ToMSet (occurs_free_fundefs B).
+#[global] Instance Occurs_free_fundefs_ToMSet (B : fundefs) : ToMSet (occurs_free_fundefs B).
 Proof.
   refine {| mset := fundefs_fv B |}.
   eapply fundefs_fv_correct.
@@ -3295,7 +3295,7 @@ Proof.
   eapply Hf2 in H; eauto.
 Qed.
 
-Instance fresh_Proper : Proper (Same_set _ ==> Logic.eq ==> iff) fresh.
+#[global] Instance fresh_Proper : Proper (Same_set _ ==> Logic.eq ==> iff) fresh.
 Proof.
   intros s1 s2 Hseq x1 x2 Heq; subst; split; intros x H.
   now rewrite <- Hseq; eauto.
@@ -3379,8 +3379,8 @@ with bound_var_fundefs_ctx: fundefs_ctx -> Ensemble var :=
                           bound_var_fundefs_ctx cfds v ->
                           bound_var_fundefs_ctx (Fcons2_c f t xs e cfds) v.
 
-Hint Constructors bound_var_ctx : core.
-Hint Constructors bound_var_fundefs_ctx : core.
+#[global] Hint Constructors bound_var_ctx : core.
+#[global] Hint Constructors bound_var_fundefs_ctx : core.
 
 Lemma bound_var_Econstr_c x t ys c :
   Same_set _ (bound_var_ctx (Econstr_c x t ys c))
@@ -4913,7 +4913,7 @@ with occurs_free_fundefs_ctx : fundefs_ctx -> Ensemble var :=
             x <> f ->
             occurs_free_fundefs_ctx (Fcons2_c f tau ys e defs) x.
 
-Hint Constructors occurs_free_ctx occurs_free_fundefs : core.
+#[global] Hint Constructors occurs_free_ctx occurs_free_fundefs : core.
 
 Lemma occurs_free_Econstr_c x t ys e :
   Same_set var (occurs_free_ctx (Econstr_c x t ys e))
@@ -5643,20 +5643,20 @@ Ltac normalize_occurs_free_ctx_in_ctx :=
     | right; now constructor
     | right].
 
-  Hint Resolve used_vars_dec : Decidable_DB.
-  Hint Resolve used_vars_fundefs_dec : Decidable_DB.
-  Hint Resolve bound_var_dec : Decidable_DB.
-  Hint Resolve bound_var_fundefs_dec : Decidable_DB.
-  Hint Resolve Decidable_occurs_free : Decidable_DB.
-  Hint Resolve Decidable_occurs_free_fundefs : Decidable_DB.
-  Hint Resolve Decidable_name_in_fundefs : Decidable_DB.
-  Hint Resolve Decidable_Empty_set : Decidable_DB.
-  Hint Resolve Decidable_Union : Decidable_DB.
-  Hint Resolve Decidable_Intersection : Decidable_DB.
-  Hint Resolve Decidable_Setminus : Decidable_DB.
-  Hint Resolve Decidable_singleton_var : Decidable_DB.
-  Hint Resolve Decidable_FromList : Decidable_DB.
-  Hint Resolve Decidable_occurs_free : Decidable_DB.
+  #[global] Hint Resolve used_vars_dec : Decidable_DB.
+  #[global] Hint Resolve used_vars_fundefs_dec : Decidable_DB.
+  #[global] Hint Resolve bound_var_dec : Decidable_DB.
+  #[global] Hint Resolve bound_var_fundefs_dec : Decidable_DB.
+  #[global] Hint Resolve Decidable_occurs_free : Decidable_DB.
+  #[global] Hint Resolve Decidable_occurs_free_fundefs : Decidable_DB.
+  #[global] Hint Resolve Decidable_name_in_fundefs : Decidable_DB.
+  #[global] Hint Resolve Decidable_Empty_set : Decidable_DB.
+  #[global] Hint Resolve Decidable_Union : Decidable_DB.
+  #[global] Hint Resolve Decidable_Intersection : Decidable_DB.
+  #[global] Hint Resolve Decidable_Setminus : Decidable_DB.
+  #[global] Hint Resolve Decidable_singleton_var : Decidable_DB.
+  #[global] Hint Resolve Decidable_FromList : Decidable_DB.
+  #[global] Hint Resolve Decidable_occurs_free : Decidable_DB.
 
   Local Ltac simplify_boolean_exprs := 
     simpl in *;

--- a/theories/LambdaANF/inline_correct.v
+++ b/theories/LambdaANF/inline_correct.v
@@ -1575,13 +1575,13 @@ Section Inline_correct.
         * destruct d. eassumption.
           destruct j. eassumption.          
           destruct (Datatypes.length l =? Datatypes.length ys)%nat eqn:Hlen; [| eassumption ]. 
-          eapply beq_nat_true in Hlen.
+          eapply Nat.eqb_eq in Hlen.
           eapply bind_triple. eapply pre_transfer_r. now eapply get_fresh_name_spec. 
           intros z w. simpl. eapply pre_curry_l. intros Hfx. eapply pre_curry_l. intros HSin. 
           { edestruct Hfm. eassumption. destructAll. eapply bind_triple.
             - do 2 eapply frame_rule. eapply pre_transfer_r. eapply IHd.
               + lia.
-              + eapply le_trans. reflexivity.
+              + eapply Nat.le_trans. reflexivity.
                 eapply NPeano.Nat.div2_decr. lia.
               + eassumption.
               + eapply Union_Disjoint_r. clear H3. now sets. now sets.
@@ -1653,7 +1653,7 @@ Section Inline_correct.
               + do 3 eapply frame_rule.
                 { eapply IHd.
                   + lia.
-                  + eapply le_trans; [| eassumption ].
+                  + eapply Nat.le_trans; [| eassumption ].
                     assert (Heq := split_fuel_add j). rewrite Heq at 3. unfold split_fuel. simpl. lia.
                   + eassumption.
                   + repeat normalize_bound_var_in_ctx. repeat normalize_occurs_free_in_ctx.
@@ -1719,7 +1719,7 @@ Section Inline_correct.
                   -- eapply HEletapp.
                   -- eapply Eletapp_OOT.
                   -- eapply HProp.
-                     eapply le_trans; [| eassumption ]. rewrite Hadd at 4. simpl. lia. 
+                     eapply Nat.le_trans; [| eassumption ]. rewrite Hadd at 4. simpl. lia. 
                   -- simpl. intros. edestruct (H20 f). constructor. now left. eassumption. eassumption.
                      destructAll. do 2 subst_exp. eapply Hrel.
                      ++ edestruct preord_env_P_inj_get_list_l. now eapply H19. normalize_occurs_free. now sets.
@@ -2030,7 +2030,7 @@ Section Inline_correct.
                     eapply Forall2_preord_var_env_map. eassumption.
                     now constructor.              
              ++ destruct ((Datatypes.length xs =?  Datatypes.length l)%nat) eqn:Hbeq.
-                { symmetry in Hbeq. eapply beq_nat_eq in Hbeq. 
+                { apply Nat.eqb_eq in Hbeq.
                   edestruct Hfm. eassumption. destructAll.
                   
                   eapply bind_triple. eapply click_spec2 with (P := fun s => fresh S (next_var s)). 

--- a/theories/LambdaANF/inline_letapp.v
+++ b/theories/LambdaANF/inline_letapp.v
@@ -271,7 +271,7 @@ Proof.
          | [ _ : context [inline_letapp ?E ?X ] |- _] => destruct (inline_letapp E X) as [[C' x''] | ] eqn:Hin'; inv Hin
          end); try congruence.
   - inv Hnum. pi0. eapply IHe in H4; eauto. destructAll. split; eauto.
-    rewrite plus_comm. constructor. eassumption.
+    rewrite Nat.add_comm. constructor. eassumption.
   - inv Hnum. pi0. eapply IHe in H5; [| eassumption |]; eauto. destructAll. split; eauto.
     constructor. eassumption.
   - inv Hnum. pi0. eapply IHe in H5; [| eassumption |]; eauto. destructAll. split; eauto.
@@ -284,7 +284,7 @@ Proof.
   - inv Hnum. eapply IHe in H4. 2:eauto. destructAll.
     split; eauto. now constructor. auto.
   - inv Hnum. pi0. eapply IHe in H4; eauto. destructAll. split; eauto.
-    rewrite plus_comm. constructor. eassumption.
+    rewrite Nat.add_comm. constructor. eassumption.
   - inv Hin. inv Hnum. 
     Transparent num_occur_list.
     simpl in *.

--- a/theories/LambdaANF/map_util.v
+++ b/theories/LambdaANF/map_util.v
@@ -80,7 +80,7 @@ Proof.
 Qed.
 
 
-Instance ToMSet_key_set {A} (rho : M.t A) : ToMSet (key_set rho).
+#[global] Instance ToMSet_key_set {A} (rho : M.t A) : ToMSet (key_set rho).
 Proof. 
   eexists (@mset (FromList (map fst (M.elements rho))) _).
   rewrite <- mset_eq, FromList_map_image_FromList.
@@ -689,7 +689,7 @@ Proof.
   auto.
 Qed.
 
-Hint Resolve not_Range_map_eq not_Dom_map_eq : core.
+#[global] Hint Resolve not_Range_map_eq not_Dom_map_eq : core.
 
 Lemma Range_map_set_list {A} xs (vs : list A) :
     Range_map (set_list (combine xs vs) (M.empty _)) \subset FromList vs.
@@ -713,7 +713,7 @@ Proof.
     exists x0. auto.
 Qed.
 
-Instance Decidable_Dom_map {A} (m : M.t A) : Decidable (Dom_map m).
+#[global] Instance Decidable_Dom_map {A} (m : M.t A) : Decidable (Dom_map m).
 Proof.
   constructor. intros x.
   destruct (M.get x m) eqn:Heq; eauto.

--- a/theories/LambdaANF/proto_util.v
+++ b/theories/LambdaANF/proto_util.v
@@ -21,7 +21,7 @@ Proof. intros Hxy Hfresh z Hz. assert (x > z)%positive by now apply Hfresh. lia.
 Lemma fresher_than_Union x S1 S2 : fresher_than x S1 -> fresher_than x S2 -> fresher_than x (S1 :|: S2).
 Proof. intros HS1 HS2 y Hy; destruct Hy as [y Hy|y Hy]; auto. Qed.
 
-Instance Proper_fresher_than_r : Proper (Logic.eq ==> Same_set _ ==> iff) fresher_than.
+#[global] Instance Proper_fresher_than_r : Proper (Logic.eq ==> Same_set _ ==> iff) fresher_than.
 Proof.
   unfold Proper, "==>", fresher_than.
   intros x y Hxy x0 y0 Hxy0; subst; split; intros Hforall dummy; now (rewrite <- Hxy0 || rewrite Hxy0).
@@ -241,9 +241,9 @@ Definition I_S_fresh {A} (C : exp_c A exp_univ_exp) (e : univD A) (x : var) : Pr
   fresher_than x (used_vars (C ⟦ e ⟧)).
 
 (* We don't have to do anything to preserve a fresh variable as we move around *)
-Instance Preserves_S_dn_S_fresh : Preserves_S_dn (@I_S_fresh).
+#[global] Instance Preserves_S_dn_S_fresh : Preserves_S_dn (@I_S_fresh).
 Proof. unfold Preserves_S_dn; intros A B C C_ok f x s; exact s. Defined.
-Instance Preserves_S_up_S_fresh : Preserves_S_up (@I_S_fresh).
+#[global] Instance Preserves_S_up_S_fresh : Preserves_S_up (@I_S_fresh).
 Proof. unfold Preserves_S_up; intros A B C C_ok f x s; exact s. Defined.
 Extraction Inline Preserves_S_dn_S_fresh Preserves_S_up_S_fresh.
 
@@ -259,9 +259,9 @@ Defined.
 (* Some passes assume unique bindings *)
 Definition I_S_uniq {A} (C : exp_c A exp_univ_exp) (e : univD A) (_ : unit) : Prop :=
   unique_bindings (C ⟦ e ⟧).
-Instance Preserves_S_dn_S_uniq : Preserves_S_dn (@I_S_uniq).
+#[global] Instance Preserves_S_dn_S_uniq : Preserves_S_dn (@I_S_uniq).
 Proof. unfold Preserves_S_dn; intros A B C C_ok f x s; exact s. Defined.
-Instance Preserves_S_up_S_uniq : Preserves_S_up (@I_S_uniq).
+#[global] Instance Preserves_S_up_S_uniq : Preserves_S_up (@I_S_uniq).
 Proof. unfold Preserves_S_up; intros A B C C_ok f x s; exact s. Defined.
 Extraction Inline Preserves_S_dn_S_uniq Preserves_S_up_S_uniq.
 

--- a/theories/LambdaANF/rel_comp.v
+++ b/theories/LambdaANF/rel_comp.v
@@ -147,7 +147,7 @@ Section RelComp.
     intros H1. revert m e3. induction H1; intros k e3 H2. 
     - econstructor. econstructor. eassumption. eassumption. eassumption.
       eassumption.
-    - rewrite <- plus_assoc. simpl.
+    - rewrite <- Nat.add_assoc. simpl.
       eapply IHR_n1.
       eapply IHR_n2. eassumption.
   Qed.
@@ -513,9 +513,9 @@ Section Linking.
           preord_exp cenv P PG k (e1, rho1) (e2, rho2)).
   Proof.
     intros H. inv H. do 2 eexists. now split; eauto.
-    eapply plus_is_one in H0. inv H0. inv H.
-    - eapply R_n_not_zero in H1. lia.
-    - inv H. eapply R_n_not_zero in H2. lia.      
+    eapply Nat.eq_add_1 in H0. inv H0. inv H.
+    - eapply R_n_not_zero in H2. lia.
+    - inv H. eapply R_n_not_zero in H1. lia.
   Qed.
   
 End Linking.

--- a/theories/LambdaANF/rename.v
+++ b/theories/LambdaANF/rename.v
@@ -180,12 +180,12 @@ Proof.
   erewrite prop_apply_r; eauto.
 Qed.
 
-Instance Proper_apply_r : Proper (@map_get_r _ ==> eq ==> eq) (apply_r).
+#[global] Instance Proper_apply_r : Proper (@map_get_r _ ==> eq ==> eq) (apply_r).
 Proof.
   intro; intros; intro; intros; subst. eapply prop_apply_r; eauto.
 Qed.
 
-Instance Proper_apply_r_list : Proper (@map_get_r _ ==> eq ==> eq) (apply_r_list).
+#[global] Instance Proper_apply_r_list : Proper (@map_get_r _ ==> eq ==> eq) (apply_r_list).
 Proof.
   intro; intros; intro; intros; subst. eapply prop_apply_r_list; eauto.
 Qed.
@@ -595,7 +595,7 @@ Proof.
   - simpl. apply proper_remove. apply IHl; eauto. 
 Qed.
 
-Instance Proper_remove_all : Proper (map_get_r _ ==> eq ==> map_get_r _) remove_all.
+#[global] Instance Proper_remove_all : Proper (map_get_r _ ==> eq ==> map_get_r _) remove_all.
 Proof.
   intro; intros; intro; intros; subst. eapply prop_remove_all; eauto.
 Qed.
@@ -774,7 +774,7 @@ Proof.
   - reflexivity.
 Qed.
 
-Instance Proper_rename_all : Proper (map_get_r _ ==> eq ==> eq) rename_all. 
+#[global] Instance Proper_rename_all : Proper (map_get_r _ ==> eq ==> eq) rename_all. 
 Proof.
   intro; intros; intro; intros; subst. eapply prop_rename_all; eauto.
 Qed.

--- a/theories/LambdaANF/set_util.v
+++ b/theories/LambdaANF/set_util.v
@@ -273,48 +273,48 @@ Qed.
 
 (* Equality morphisms *)
 
-Instance Proper_In x :  Proper (Equal ==> iff) (In x).
+#[global] Instance Proper_In x :  Proper (Equal ==> iff) (In x).
 Proof.
   constructor; intros Hin; eapply H; eauto.
 Qed.
 
-Instance Proper_union_r x :  Proper (Equal ==> Equal) (union x).
+#[global] Instance Proper_union_r x :  Proper (Equal ==> Equal) (union x).
 Proof.
   constructor; intros Hin; apply_set_specs_ctx; apply_set_specs; eauto;
   right; apply H; eauto.
 Qed.
 
-Instance Proper_union_l :  Proper (Equal ==> Logic.eq ==> Equal) union.
+#[global] Instance Proper_union_l :  Proper (Equal ==> Logic.eq ==> Equal) union.
 Proof.
   constructor; intros; apply_set_specs_ctx; apply_set_specs; eauto;
   left; apply H; eauto.
 Qed.
 
-Instance Proper_elements :  Proper (Equal ==> Logic.eq) elements.
+#[global] Instance Proper_elements :  Proper (Equal ==> Logic.eq) elements.
 Proof.
   intros x y Heq; eauto. eapply elements_eq. eassumption.
 Qed.
 
-Instance Proper_carinal :  Proper (Equal ==> Logic.eq) cardinal.
+#[global] Instance Proper_carinal :  Proper (Equal ==> Logic.eq) cardinal.
 Proof.
   intros x y Heq; eauto. rewrite !cardinal_spec, Heq. reflexivity.
 Qed.
 
-Instance union_proper_l :  Proper (PS.Equal ==> eq ==> PS.Equal) PS.union.
+#[global] Instance union_proper_l :  Proper (PS.Equal ==> eq ==> PS.Equal) PS.union.
 Proof.
   intros x y Heq1 x' y' Heq2; subst.
   intros z; split; intros Hin; eapply PS.union_spec in Hin;
   inv Hin; eapply PS.union_spec; now firstorder.
 Qed.
 
-Instance diff_proper_l :  Proper (PS.Equal ==> eq ==> PS.Equal) PS.diff.
+#[global] Instance diff_proper_l :  Proper (PS.Equal ==> eq ==> PS.Equal) PS.diff.
 Proof.
   intros x y Heq1 x' y' Heq2; subst.
   intros z; split; intros Hin; eapply PS.diff_spec in Hin;
   inv Hin; eapply PS.diff_spec; now firstorder.
 Qed.
 
-Instance diff_proper_r :  Proper (eq ==> PS.Equal ==> PS.Equal) PS.diff.
+#[global] Instance diff_proper_r :  Proper (eq ==> PS.Equal ==> PS.Equal) PS.diff.
 Proof.
   intros x y Heq1 x' y' Heq2; subst.
   intros z; split; intros Hin; eapply PS.diff_spec in Hin;
@@ -564,14 +564,14 @@ Proof.
   now inv Hin. now inv Hc.
 Qed.
 
-Instance Decidable_FromSet (s : PS.t) : Decidable (FromSet s).
+#[global] Instance Decidable_FromSet (s : PS.t) : Decidable (FromSet s).
 Proof.
   unfold FromSet.
   eapply Ensembles_util.Decidable_FromList. 
 Qed.
 
 
-Instance Proper_From_set : Proper (PS.Equal ==> Same_set _) FromSet.
+#[global] Instance Proper_From_set : Proper (PS.Equal ==> Same_set _) FromSet.
 Proof.
   constructor.
   - intros z Hin. eapply FromSet_sound in Hin; [| reflexivity ].
@@ -598,19 +598,19 @@ Class ToMSet (S : Ensemble positive) :=
     mset_eq : S <--> FromSet mset
   }.
 
-Instance ToMSet_EmptySet : ToMSet (Empty_set _).
+#[global] Instance ToMSet_EmptySet : ToMSet (Empty_set _).
 Proof.
   econstructor. 
   symmetry. eapply FromSet_empty.
 Defined.
 
-Instance ToMSet_Singleton x : ToMSet [set x].
+#[global] Instance ToMSet_Singleton x : ToMSet [set x].
 Proof.
   econstructor. 
   symmetry. eapply FromSet_singleton.
 Defined.
 
-Instance ToMSet_Same_set (S1 S2 : Ensemble positive) :
+#[global] Instance ToMSet_Same_set (S1 S2 : Ensemble positive) :
   S1 <--> S2 ->
   ToMSet S1 ->
   ToMSet S2.
@@ -619,7 +619,7 @@ Proof.
   econstructor. eassumption.
 Qed.
 
-Instance ToMSet_image'_Singleton {A} (f : A -> option positive) (x : A) :
+#[global] Instance ToMSet_image'_Singleton {A} (f : A -> option positive) (x : A) :
   ToMSet (image' f [set x]).
 Proof.
   destruct (f x) eqn:Heq.
@@ -629,21 +629,21 @@ Proof.
   symmetry. eapply FromSet_empty.
 Defined.
 
-Instance ToMSet_Union S1 {H1 : ToMSet S1} S2 {H2 : ToMSet S2} : ToMSet (S1 :|: S2).
+#[global] Instance ToMSet_Union S1 {H1 : ToMSet S1} S2 {H2 : ToMSet S2} : ToMSet (S1 :|: S2).
 Proof.
   destruct H1 as [m1 Heq1]. destruct H2 as [m2 Heq2].  
   econstructor. symmetry. rewrite FromSet_union.
   rewrite Heq1, Heq2. reflexivity. 
 Qed.  
 
-Instance ToMSet_Setminus S1 {H1 : ToMSet S1} S2 {H2 : ToMSet S2} : ToMSet (S1 \\ S2).
+#[global] Instance ToMSet_Setminus S1 {H1 : ToMSet S1} S2 {H2 : ToMSet S2} : ToMSet (S1 \\ S2).
 Proof.
   destruct H1 as [m1 Heq1]. destruct H2 as [m2 Heq2].  
   econstructor. symmetry. rewrite FromSet_diff.
   rewrite Heq1, Heq2. reflexivity. 
 Qed.
 
-Instance ToMSet_Intersection (S1 : Ensemble positive) `{ToMSet S1}
+#[global] Instance ToMSet_Intersection (S1 : Ensemble positive) `{ToMSet S1}
          (S2 : Ensemble positive) `{ToMSet S2} : ToMSet (S1 :&: S2).
 Proof.
   destruct H as [m1 Hm1]; destruct H0 as [m2 Hm2].
@@ -661,14 +661,14 @@ Proof.
     eapply FromSet_complete. eapply Hm2; eauto. eassumption. 
 Qed.
 
-Instance ToMSetFromList l : ToMSet (FromList l).
+#[global] Instance ToMSetFromList l : ToMSet (FromList l).
 Proof.
   eexists (union_list PS.empty l).
   rewrite FromSet_union_list. rewrite FromSet_empty.
   rewrite Union_Empty_set_neut_l. reflexivity.
 Defined.
   
-Instance Decidable_ToMSet S {HM : ToMSet S} : Decidable S.
+#[global] Instance Decidable_ToMSet S {HM : ToMSet S} : Decidable S.
 Proof.
   constructor. intros x.
   destruct HM as [m Heq].
@@ -815,7 +815,7 @@ Proof with (now eauto with Ensembles_DB).
 Qed.
 
   
-Instance ImageToMSet b S `{_: ToMSet S} : ToMSet (image b S).
+#[global] Instance ImageToMSet b S `{_: ToMSet S} : ToMSet (image b S).
 Proof.
   destruct H as [m Hm].
   exists (PS_map b m).  rewrite Hm. unfold PS_map.
@@ -828,7 +828,7 @@ Proof.
   now eauto with Ensembles_DB.
 Qed.
 
-Instance Image'ToMSet b S `{_: ToMSet S} : ToMSet (image' b S).
+#[global] Instance Image'ToMSet b S `{_: ToMSet S} : ToMSet (image' b S).
 Proof.
   destruct H as [m Hm].
   exists (PS_map_opt b m).  rewrite Hm. unfold PS_map_opt.

--- a/theories/LambdaANF/shrink_cps.v
+++ b/theories/LambdaANF/shrink_cps.v
@@ -91,7 +91,7 @@ Section MEASURECONTRACT.
     unfold svalue_inl_size.
     simpl.
     destruct (get_b i im).
-    apply Peano.le_0_n.
+    apply Nat.le_0_l.
     auto.
   Defined.
 
@@ -141,13 +141,13 @@ Section MEASURECONTRACT.
   Theorem min_term_size:
     forall e, 1 <= term_size e.
   Proof. intro.
-         destruct e; simpl; apply lt_le_S; apply Nat.lt_0_succ.
+         destruct e; simpl; apply Nat.le_succ_l; apply Nat.lt_0_succ.
   Defined.
 
   Theorem min_funs_size:
     forall f, 1 <= funs_size f.
   Proof.
-    destruct f; simpl; apply lt_le_S; apply Nat.lt_0_succ.
+    destruct f; simpl; apply Nat.le_succ_l; apply Nat.lt_0_succ.
   Defined.
 
 
@@ -676,11 +676,11 @@ Section CONTRACT.
         rewrite Nat.add_comm. rewrite <- Nat.add_assoc. rewrite <- Nat.add_succ_l.
         rewrite <- Nat.add_0_r with (n :=sub_inl_size sub' im ).
         rewrite Nat.add_comm.
-        apply Nat.add_le_mono.  apply le_0_n.
+        apply Nat.add_le_mono. apply Nat.le_0_l.
         rewrite Nat.add_comm. apply H0.
         rewrite <- Nat.add_succ_r.
         rewrite <- Nat.add_0_r with (n := funs_size fds').
-        apply Nat.add_le_mono. assumption. apply le_0_n.
+        apply Nat.add_le_mono. assumption. apply Nat.le_0_l.
       + assert (exists fds' count' sub', (fds', count', sub') = precontractfun sig count sub fds).
         destruct (precontractfun sig count sub fds). destruct p.
         eauto. destructAll. assert (H0' := H0).
@@ -802,7 +802,7 @@ Section CONTRACT.
     rewrite <- Nat.add_succ_r in pfe.
     unfold lt in pfe. rewrite <- Nat.add_succ_l in pfe. eapply Nat.le_trans. 2: apply pfe.
     rewrite <- Nat.add_0_r with (n := S (term_size e)) at 1. rewrite Nat.add_comm.
-    apply Nat.add_le_mono. apply le_0_n. reflexivity.
+    apply Nat.add_le_mono. apply Nat.le_0_l. reflexivity.
     assumption.
   Defined.
 
@@ -1080,7 +1080,8 @@ Section CONTRACT.
     apply Nat.add_lt_mono_r. assumption.
   Defined.
   Next Obligation.
-    assert ((forall im, sub_inl_size sub' im <= funs_size (fl) + sub_inl_size sub im /\ funs_size fl' <= funs_size fl))%nat. eapply precontractfun_size. eauto.  unfold term_sub_inl_size. simpl. specialize (H im). apply le_lt_n_Sm. destruct H.
+    assert ((forall im, sub_inl_size sub' im <= funs_size (fl) + sub_inl_size sub im /\ funs_size fl' <= funs_size fl))%nat. eapply precontractfun_size. eauto.  unfold term_sub_inl_size. simpl. specialize (H im).
+    apply Nat.lt_succ_r. destruct H.
     rewrite Nat.add_comm with (n := funs_size fl).
     rewrite <- Nat.add_assoc.
     apply Nat.add_le_mono. reflexivity. apply H.
@@ -1121,9 +1122,10 @@ Section CONTRACT.
     unfold term_sub_inl_size; simpl.
     symmetry in H1.
     apply sub_inl_fun_size with (im :=  im) in H1.
-    eapply le_lt_trans. eapply plus_le_compat_r. eapply term_size_inline_letapp.
+    eapply Nat.le_lt_trans. apply -> Nat.add_le_mono_r. 
+    eapply term_size_inline_letapp.
     now eauto. rewrite (proj1 (term_size_rename_all_ns _)).    
-    rewrite plus_comm, plus_assoc.
+    rewrite Nat.add_comm, Nat.add_assoc.
     rewrite <- H1. lia.
     symmetry in Heq2.
     apply Bool.andb_true_iff in Heq2.
@@ -1426,4 +1428,4 @@ Definition shrink_n_times (e:exp) (n:nat): exp :=
 
 
 (* Wrap the shrink reducer so that it has the same type as other ANF transformations *)
-Definition shrink_err (e : exp) (c : comp_data) := (compM.Ret (fst (shrink_cps.shrink_top e)), c). 
+Definition shrink_err (e : exp) (c : comp_data) := (compM.Ret (fst (shrink_cps.shrink_top e)), c).

--- a/theories/LambdaANF/shrink_cps_correct.v
+++ b/theories/LambdaANF/shrink_cps_correct.v
@@ -2250,13 +2250,13 @@ Section occurs_free_rw.
     2: reflexivity.
     simpl.
 
-    inv H0. apply plus_is_O in H3. destruct H3. subst.
+    inv H0. apply Nat.eq_add_0 in H3. destruct H3. subst.
     apply fundefs_append_num_occur' in H6.
     destructAll.
-    apply plus_is_O in H2. destructAll.
+    apply Nat.eq_add_0 in H2. destructAll.
 
 
-    inv H1. apply plus_is_O in H10.
+    inv H1. apply Nat.eq_add_0 in H10.
     destructAll.
     apply not_occurs_not_free in H5.
     apply not_occurs_not_free in H11.
@@ -3158,14 +3158,14 @@ substitution to a term cannot increase the occurence count for that variable. *)
     - simpl in H1. inv H1.
       inv H0.
       specialize (H _ _ _  H8 H9).
-      apply plus_le_compat.
+      apply Nat.add_le_mono.
       apply H. intro. apply H2.
       apply Range_map_remove in H0. auto.
       apply num_occur_list_not_range. auto.
     - simpl in H0. inv H0.
       inv H6. inv H.
       inv H5.
-      apply plus_le_compat.
+      apply Nat.add_le_mono.
       assert (Hll := num_occur_list_not_range _ _ H1 ([v])).
       simpl in Hll.    auto.
       auto.
@@ -3174,7 +3174,7 @@ substitution to a term cannot increase the occurence count for that variable. *)
           (n + (num_occur_list [v] f + m)) by lia.
       replace ((num_occur_list (@cons var (apply_r sigma v) (@nil var)) f) + (n0 + m0)) with
           (n0 + (num_occur_list (@cons var (apply_r sigma v) (@nil var)) f + m0)) by lia.
-      apply plus_le_compat.
+      apply Nat.add_le_mono.
       eapply H; eauto.
       eapply H0; eauto.
       simpl. constructor.
@@ -3183,7 +3183,7 @@ substitution to a term cannot increase the occurence count for that variable. *)
     - simpl in H1. inv H1.
       inv H0.
       specialize (H _ _ _ H9 H10).
-      apply plus_le_compat.
+      apply Nat.add_le_mono.
       assert (Hll := num_occur_list_not_range _ _ H2 ([v0])).
       simpl in Hll.    auto.
       apply H. intro; apply H2.
@@ -3191,12 +3191,12 @@ substitution to a term cannot increase the occurence count for that variable. *)
       auto.
     - inv H1. inv H0.
       assert (Hll := num_occur_list_not_range _ _ H2 (f0::ys)).
-      apply plus_le_compat. eassumption.
+      apply Nat.add_le_mono. eassumption.
       eapply H. eassumption. eassumption. intros Hc.
       apply Range_map_remove in Hc. auto.
     - inv H1.
       simpl in H2. inv H2.
-      apply plus_le_compat.
+      apply Nat.add_le_mono.
       eapply H0; eauto.
       intro; apply H3.
       apply Range_map_remove_all in H1.
@@ -3215,7 +3215,7 @@ substitution to a term cannot increase the occurence count for that variable. *)
       intro; apply H2.
       apply (@Range_map_remove var) in H0. auto.
     - inv H0; inv H1.
-      apply plus_le_compat.
+      apply Nat.add_le_mono.
       eapply H; eauto.
       intro; apply H2.
       apply (@Range_map_remove var) in H0. auto.
@@ -3224,7 +3224,7 @@ substitution to a term cannot increase the occurence count for that variable. *)
       assert (Hll := num_occur_list_not_range _ _ H1 ([v])).
       auto.
     - inv H1; inv H2.
-      apply plus_le_compat.
+      apply Nat.add_le_mono.
       eapply H; eauto.
       intro; apply H3.
       apply Range_map_remove_all in H1. auto.
@@ -3264,8 +3264,8 @@ substitution to a term cannot increase the occurence count for that variable. *)
       lia.
     - inv H; inv H0.
       inv H5; inv H4.
-      rewrite plus_0_r.
-      rewrite plus_0_r.
+      rewrite Nat.add_0_r.
+      rewrite Nat.add_0_r.
       apply (num_occur_list_not_range _ _ Hs [v]).
     - inv H1. inv H2.
       inv H7. inv H6.
@@ -3345,14 +3345,14 @@ substitution to a term cannot increase the occurence count for that variable. *)
     - simpl in H1. inv H1.
       inv H0.
       specialize (H _ _ _  H8 H9).
-      apply plus_le_compat.
+      apply Nat.add_le_mono.
       apply H. intro. apply H2.
       auto.
       apply num_occur_list_not_dom. auto.
     - simpl in H0. inv H0.
       inv H6. inv H.
       inv H5.
-      apply plus_le_compat.
+      apply Nat.add_le_mono.
       apply (num_occur_list_not_dom _ _ H1 ([v])).
       auto.
     - simpl in H2. inv H1. inv H2. inv H8. inv H7.
@@ -3360,7 +3360,7 @@ substitution to a term cannot increase the occurence count for that variable. *)
           (n + (num_occur_list [v] f + m)) by lia.
       replace (Init.Nat.add (num_occur_list (@cons var (apply_r sigma v) (@nil var)) f) (Init.Nat.add n0 m0)) with
           (n0 + (num_occur_list (@cons var (apply_r sigma v) (@nil var)) f + m0)) by lia.
-      apply plus_le_compat.
+      apply Nat.add_le_mono.
       eapply H; eauto.
       eapply H0; eauto.
       simpl. constructor.
@@ -3368,7 +3368,7 @@ substitution to a term cannot increase the occurence count for that variable. *)
     - simpl in H1. inv H1.
       inv H0.
       specialize (H _ _ _ H9 H10).
-      apply plus_le_compat.
+      apply Nat.add_le_mono.
       assert (Hll := num_occur_list_not_dom _ _ H2 ([v0])).
       simpl in Hll.    auto.
       apply H. intro; apply H2.
@@ -3376,12 +3376,12 @@ substitution to a term cannot increase the occurence count for that variable. *)
     - simpl in H1. inv H1.
       inv H0.
       specialize (H _ _ _  H9 H10).
-      apply plus_le_compat.
+      apply Nat.add_le_mono.
       assert (Hll := num_occur_list_not_dom _ _ H2 (f0::ys)). eassumption.
       eauto.
     - inv H1.
       simpl in H2. inv H2.
-      apply plus_le_compat.
+      apply Nat.add_le_mono.
       eapply H0; eauto.
       eapply H; eauto.
     - inv H. inv H0.
@@ -3391,7 +3391,7 @@ substitution to a term cannot increase the occurence count for that variable. *)
     - inv H0; inv H1.
       eapply H; eauto.
     - inv H0; inv H1.
-      apply plus_le_compat.
+      apply Nat.add_le_mono.
       eapply H; eauto.
       apply num_occur_list_not_dom.
       auto.
@@ -3399,7 +3399,7 @@ substitution to a term cannot increase the occurence count for that variable. *)
       assert (Hll := num_occur_list_not_dom _ _ H1 ([v])).
       auto.
     - inv H1; inv H2.
-      apply plus_le_compat.
+      apply Nat.add_le_mono.
       eapply H; eauto.
 
       eapply H0; eauto.
@@ -3482,29 +3482,29 @@ substitution to a term cannot increase the occurence count for that variable. *)
     intros f x y sigma Hdom Hfy; apply exp_def_mutual_ind; intros; simpl in *; try (inv H0; inv H1).
     - assert (Hl := num_occur_list_set_not_x f y x _ Hdom Hfy l).
       specialize (H _ _ H8 H7).
-      apply plus_le_compat; eauto.
+      apply Nat.add_le_mono; eauto.
     - inv H; inv H0.
       inv H5; inv H4.
       assert (Hl := num_occur_list_set_not_x).
       specialize (Hl f y x _ Hdom Hfy [v]).
       simpl in Hl.
       simpl.
-      do 2 (rewrite plus_0_r).
+      do 2 (rewrite Nat.add_0_r).
       auto.
     - inv H1; inv H2.
       inv H7; inv H6.
       rewrite OrdersEx.Nat_as_OT.add_shuffle3.
       rewrite  OrdersEx.Nat_as_OT.add_shuffle3 with (p := m0).
-      apply plus_le_compat; eauto.
+      apply Nat.add_le_mono; eauto.
     - assert (Hl := num_occur_list_set_not_x).
       specialize (Hl f y x _ Hdom Hfy [v0]).
       specialize (H _ _ H9 H8).
       simpl; simpl in Hl.
-      apply plus_le_compat; eauto.
+      apply Nat.add_le_mono; eauto.
     - assert (Hl := num_occur_list_set_not_x f y x _ Hdom Hfy (f0 :: ys)).
-      apply plus_le_compat; eauto.      
+      apply Nat.add_le_mono; eauto.      
     - inv H1; inv H2.
-      apply plus_le_compat; eauto.
+      apply Nat.add_le_mono; eauto.
     - inv H; inv H0.
       assert (Hl := num_occur_list_set_not_x).
       specialize (Hl f y x _ Hdom Hfy (v::l)).
@@ -3512,12 +3512,12 @@ substitution to a term cannot increase the occurence count for that variable. *)
     - assert (Hl := num_occur_list_set_not_x f y x _ Hdom Hfy [v]).
       eauto.
     - assert (Hl := num_occur_list_set_not_x f y x _ Hdom Hfy l).
-       apply plus_le_compat; eauto.
+       apply Nat.add_le_mono; eauto.
     - inv H; inv H0.
       assert (Hl := num_occur_list_set_not_x f y x _ Hdom Hfy [v]).
       auto.
     - inv H1; inv H2.
-      apply plus_le_compat; eauto.
+      apply Nat.add_le_mono; eauto.
     - inv H; inv H0; auto.
   Qed.
   
@@ -3536,30 +3536,30 @@ substitution to a term cannot increase the occurence count for that variable. *)
     intros f x y Hfy; apply exp_def_mutual_ind; intros; simpl in *; try (inv H0; inv H1).
     - assert (Hl := num_occur_list_set _ _ x sigma Hfy l).
       specialize (H _ _ _ H8 H7).
-      apply plus_le_compat; eauto.
+      apply Nat.add_le_mono; eauto.
     - inv H; inv H0.
       inv H5; inv H4.
       assert (Hl := num_occur_list_set).
       specialize (Hl _ _ x sigma Hfy [v]).
       simpl in Hl.
       simpl.
-      do 2 (rewrite plus_0_r).
+      do 2 (rewrite Nat.add_0_r).
       auto.
     - inv H1; inv H2.
       inv H7; inv H6.
       rewrite OrdersEx.Nat_as_OT.add_shuffle3.
       rewrite  OrdersEx.Nat_as_OT.add_shuffle3 with (p := m).
-      apply plus_le_compat; eauto.
+      apply Nat.add_le_mono; eauto.
     - assert (Hl := num_occur_list_set).
       specialize (Hl _ _ x sigma Hfy [v0]).
       specialize (H _ _ _ H9 H8).
       simpl; simpl in Hl.
-      apply plus_le_compat; eauto.
+      apply Nat.add_le_mono; eauto.
     - assert (Hl := num_occur_list_set).
       specialize (Hl _ _ x sigma Hfy (f0::ys)).
-      apply plus_le_compat; eauto.
+      apply Nat.add_le_mono; eauto.
     - inv H1; inv H2.
-      apply plus_le_compat; eauto.
+      apply Nat.add_le_mono; eauto.
     - inv H; inv H0.
       assert (Hl := num_occur_list_set).
       specialize (Hl _ _ x sigma Hfy (v::l)).
@@ -3567,12 +3567,12 @@ substitution to a term cannot increase the occurence count for that variable. *)
     - assert (Hl := num_occur_list_set _ _ x sigma Hfy [v]).
       eauto.
     - assert (Hl := num_occur_list_set _ _ x sigma Hfy l).
-      apply plus_le_compat; eauto.
+      apply Nat.add_le_mono; eauto.
     - inv H; inv H0.
       assert (Hl := num_occur_list_set _ _ x sigma Hfy [v]).
       auto.
     - inv H1; inv H2.
-      apply plus_le_compat; eauto.
+      apply Nat.add_le_mono; eauto.
     - inv H; inv H0; auto.
   Qed.
 
@@ -3602,7 +3602,7 @@ substitution to a term cannot increase the occurence count for that variable. *)
     assert (exists n, num_occur e v n) by apply e_num_occur.
     inv H1.
     assert (Hn0 := proj1 (num_occur_rename_all_not_dom_mut v) _ _ _ _ H2 H0 H).
-    apply le_n_0_eq in Hn0. subst; auto.
+    apply Nat.le_0_r in Hn0. subst; auto.
   Qed.
 
   Definition rename_all_case sigma cl := (List.map (fun (p:var*exp) => let (k, e) := p in
@@ -3620,7 +3620,7 @@ substitution to a term cannot increase the occurence count for that variable. *)
     induction cl; intros.
     - inv H; inv H0; auto.
     - inv H; inv H0.
-      apply plus_le_compat.
+      apply Nat.add_le_mono.
       eapply (proj1 (num_occur_rename_all_not_dom_mut _)); eauto.
       eauto.
   Qed.
@@ -3735,10 +3735,10 @@ substitution to a term cannot increase the occurence count for that variable. *)
       split.
       eapply num_occur_n. constructor; eauto.
       assert (Hn := num_occur_arl _ _ [v] Hxy).
-      simpl in Hn. simpl.  rewrite plus_0_r. auto.
+      simpl in Hn. simpl.  rewrite Nat.add_0_r. auto.
       eapply num_occur_n. constructor. auto.
       assert (Hnn := num_occur_set_arl _ _ Hxy [v]).
-      simpl. simpl in Hnn. do 3 (rewrite plus_0_r). rewrite Plus.plus_comm. auto.
+      simpl. simpl in Hnn. do 3 (rewrite Nat.add_0_r). rewrite Nat.add_comm. auto.
     - inv H1; inv H2. inv H7; inv H6.
       specialize (H _ _ H8 H7).
       assert (num_occur (Ecase v l) x ( num_occur_list [v] x + m)).
@@ -3760,7 +3760,7 @@ substitution to a term cannot increase the occurence count for that variable. *)
       split.
       eapply num_occur_n. constructor; eauto.
       assert (Hn := num_occur_arl _ _ [v0] Hxy).
-      simpl in Hn. simpl. rewrite plus_0_r. auto.
+      simpl in Hn. simpl. rewrite Nat.add_0_r. auto.
       eapply num_occur_n. constructor; eauto.
       assert (Hnn := num_occur_set_arl _ _ Hxy [v0]).
       simpl. simpl in Hnn. unfold var in *. unfold M.elt in *. rewrite Hnn. lia.
@@ -3825,45 +3825,45 @@ substitution to a term cannot increase the occurence count for that variable. *)
     - simpl in H0. inv H0.
       inv H.
       specialize (IHc _ _ _  H7 H8).
-      apply plus_le_compat.
+      apply Nat.add_le_mono.
       apply num_occur_list_not_dom. auto.
       apply IHc. auto.
     - simpl in H0. inv H0.
       inv H.
-      apply plus_le_compat.
+      apply Nat.add_le_mono.
       apply (num_occur_list_not_dom _ _ H1 ([v0])).
       eauto.
     - simpl in H0. inv H0.
       inv H.
       specialize (IHc _ _ _  H8 H9).
-      apply plus_le_compat.
+      apply Nat.add_le_mono.
       assert (Hll := num_occur_list_not_dom _ _ H1 (f0::ys)). eassumption.
       eauto.
     - simpl in H0. inv H0; inv H. eauto.
     - simpl in H0. inv H0. inv H.
-      apply plus_le_compat.
+      apply Nat.add_le_mono.
       apply num_occur_list_not_dom; auto.
       eauto.
     - simpl in H0. inv H0.
       inv H.
-      repeat apply plus_le_compat.
+      repeat apply Nat.add_le_mono.
       apply (num_occur_list_not_dom _ _ H1 ([v])).
       2: eauto.
       eapply num_occur_case_rename_all_ns_not_dom; eauto.
       eapply num_occur_case_rename_all_ns_not_dom; eauto.
     - inv H.
       simpl in H0. inv H0.
-      apply plus_le_compat; eauto.
+      apply Nat.add_le_mono; eauto.
       eapply (proj2 (num_occur_rename_all_not_dom_mut _)); eauto.
     - inv H. inv H0.
-      apply plus_le_compat; eauto.
+      apply Nat.add_le_mono; eauto.
       eapply (proj1 (num_occur_rename_all_not_dom_mut _)); eauto.
     - inv H.
       simpl in H0. inv H0.
-      apply plus_le_compat; eauto.
+      apply Nat.add_le_mono; eauto.
       eapply (proj2 (num_occur_rename_all_not_dom_mut _)); eauto.
     - inv H. inv H0.
-      apply plus_le_compat; eauto.
+      apply Nat.add_le_mono; eauto.
       eapply (proj1 (num_occur_rename_all_not_dom_mut _)); eauto.
   Qed.
 
@@ -3889,7 +3889,7 @@ substitution to a term cannot increase the occurence count for that variable. *)
     assert (exists n, num_occur_ec c v n) by apply e_num_occur_ec.
     inv H1.
     assert (Hn0 := proj1 (num_occur_rename_all_ctx_not_dom_mut v) _ _ _ _ H2 H0 H).
-    apply le_n_0_eq in Hn0. subst; auto.
+    apply Nat.le_0_r in Hn0. subst; auto.
   Qed.
 
 
@@ -3982,13 +3982,13 @@ substitution to a term cannot increase the occurence count for that variable. *)
       intro.
       apply Range_map_set_list in H4.
       apply not_occur_list in H3. auto.
-      apply le_n_0_eq in H4.
+      apply Nat.le_0_r in H4.
       subst. auto.
-      rewrite <- plus_0_l.
+      rewrite <- Nat.add_0_l.
       eapply fundefs_append_num_occur.
       reflexivity.
       auto.
-      rewrite <- plus_0_l.
+      rewrite <- Nat.add_0_l.
       constructor; auto.
     }
   Qed.

--- a/theories/LambdaANF/shrink_cps_corresp.v
+++ b/theories/LambdaANF/shrink_cps_corresp.v
@@ -469,7 +469,7 @@ Section CENSUS.
     - rewrite gdso by auto.
       rewrite gdso by auto.
       rewrite gdempty.
-      rewrite <- minus_n_O.
+      rewrite Nat.sub_0_r.
       auto.
   Qed.
 
@@ -481,7 +481,7 @@ Section CENSUS.
                (update_census_list sig l c_minus count).
   Proof.
     revert count sig; induction l; intros count sig.
-    - simpl. intro. rewrite gccombine_sub. rewrite gdempty. rewrite minus_n_O. auto.
+    - simpl. intro. rewrite gccombine_sub. rewrite gdempty. rewrite Nat.sub_0_r. auto.
     - simpl. intro. rewrite gccombine_sub. rewrite <- IHl.
       simpl. rewrite gccombine_sub. rewrite apply_r_empty.
       rewrite init_census_f_ar_l.
@@ -699,7 +699,7 @@ Section CONTRACT.
   Ltac pi0 :=
   repeat match goal with
          | [ H: _ + _ = 0 |- _ ] =>
-           apply plus_is_O in H; destruct H; subst
+           apply Nat.eq_add_0 in H; destruct H; subst
          | [ H: 0 = _ + _ |- _ ] =>
            symmetry in H; pi0
          (* | [ H: (if cps_util.var_dec ?X ?Y then _ else _) = 0 |- _] => *)
@@ -756,9 +756,9 @@ Section CONTRACT.
        inv H2; pi0.
        apply num_occur_app_ctx. eexists 0, 0; eauto.
        split; auto. split; auto.
-       rewrite <- plus_0_l.
+       rewrite <- Nat.add_0_l.
        constructor; auto.
-       rewrite <- plus_0_l.
+       rewrite <- Nat.add_0_l.
        eapply fundefs_append_num_occur; eauto.
     - apply num_occur_app_ctx in H7; destructAll; pi0.
       apply num_occur_app_ctx. eexists 0, 0; eauto.
@@ -772,8 +772,8 @@ Section CONTRACT.
       assert (exists n, num_occur e0 x0 n) by apply e_num_occur.
       destruct H4.
       assert (x1 <= 0).
-      eapply num_occur_case_le; eauto.
-      apply le_n_0_eq in H5. subst; auto.
+      eapply num_occur_case_le; eauto. 
+      apply Nat.le_0_r in H5. subst; auto.
       lia. auto.
     - apply num_occur_app_ctx in H7; destructAll; pi0.
       inv H3; pi0.
@@ -794,7 +794,7 @@ Section CONTRACT.
       auto.
       rewrite M.gso in H6; auto. rewrite M.gempty in H6.
       inv H6.
-      apply le_n_0_eq in H5; subst; auto.
+      apply Nat.le_0_r in H5; subst; auto.
 
       reflexivity. auto.
     - inv H2; pi0.
@@ -814,7 +814,7 @@ Section CONTRACT.
       eapply num_occur_rename_all_ns_not_range. eassumption. eassumption. 
       intro Hr. apply Range_map_set_list in Hr.
       apply not_occur_list in Hr; eauto. 
-      apply le_n_0_eq in H4. subst; auto.
+      apply Nat.le_0_r in H4. subst; auto.
       reflexivity.
       eapply fundefs_append_num_occur; eauto.
       auto.
@@ -938,7 +938,7 @@ Section CONTRACT.
     assert (x <= 0).
     eapply num_occur_rename_all_not_dom_mut.
     apply H1. apply H0. auto.
-    apply le_n_0_eq in H2. subst; auto.
+    apply Nat.le_0_r in H2. subst; auto.
   Qed.
 
 
@@ -1508,7 +1508,7 @@ Section CONTRACT.
       destruct Hcpc.
       rewrite <- H1. rewrite gccombine'.
       rewrite <- (proj1 rename_all_ns_empty).
-      unfold init_census_f. apply plus_comm.
+      unfold init_census_f. apply Nat.add_comm.
     - eapply num_occur_constr.
       constructor.
       unfold init_census. simpl.
@@ -1536,7 +1536,7 @@ Section CONTRACT.
       rewrite apply_r_list_empty.
       rewrite gdempty.
       simpl.
-      apply plus_comm.
+      apply Nat.add_comm.
     - unfold init_census.
       eapply num_occur_constr.
       constructor.
@@ -1714,7 +1714,7 @@ Section CONTRACT.
     - intro.
       rewrite gccombine_sub.
       rewrite gdempty.
-      rewrite minus_n_O. reflexivity.
+      rewrite Nat.sub_0_r. reflexivity.
   Qed.
 
 
@@ -3340,7 +3340,7 @@ Section CONTRACT.
     gsr_clos (n + m) e1 e3.
   Proof.
     intros H1 H2. induction H1.
-    + rewrite <- plus_assoc. econstructor; eauto.
+    + rewrite <- Nat.add_assoc. econstructor; eauto.
     + eassumption.
   Qed.
       
@@ -3757,7 +3757,7 @@ Section CONTRACT.
     destruct H1.
     assert (x0 <= 0).
     eapply (proj1 (num_occur_rename_all_ns_set f x y H)); eauto.
-    apply le_n_0_eq in H2.
+    apply Nat.le_0_r in H2.
     subst; auto.
   Qed.
 
@@ -4099,7 +4099,7 @@ Section CONTRACT.
     destruct H1.
     assert (x0 <= 0).
     eapply num_occur_rename_all_ns_set_list; eauto.
-    apply le_n_0_eq in H2. subst; auto.
+    apply Nat.le_0_r in H2. subst; auto.
   Qed.
 
   Theorem length_apply_r_list:
@@ -4141,7 +4141,7 @@ Section CONTRACT.
       destruct (get_b v im').
       specialize (IHf4 _ _ H10 H1). lia.
       inv H1.
-      apply plus_le_compat; eauto.
+      apply Nat.add_le_mono; eauto.
       apply Nat.eq_le_incl.
       eapply (proj1 (num_occur_det _)); eauto.
     - inv H0; inv H1; auto.
@@ -4174,15 +4174,15 @@ Section CONTRACT.
   Proof.
     intros im im' Him f.
     exp_fundefs_ctx_induction IHc IHf; intros nn mm Hn Hm; simpl in *;
-    try (inversion Hn; inversion Hm; subst); auto; try (apply plus_le_compat; eauto).
+    try (inversion Hn; inversion Hm; subst); auto; try (apply Nat.add_le_mono; eauto).
     - intro. simpl in *. inv H. simpl.
-      repeat apply plus_le_compat; eauto.
+      repeat apply Nat.add_le_mono; eauto.
       apply Nat.eq_le_incl.
       eapply num_occur_case_det; eauto.
       apply Nat.eq_le_incl.
       eapply num_occur_case_det; eauto.
     - intro. inversion H0; subst.
-      repeat apply plus_le_compat; eauto.
+      repeat apply Nat.add_le_mono; eauto.
       apply Nat.eq_le_incl.
       eapply num_occur_case_det; eauto.
       apply Nat.eq_le_incl.
@@ -4209,7 +4209,7 @@ Section CONTRACT.
     destruct H1.
     assert (x <= 0).
     eapply (proj1 (num_occur_ec_le_antimon _ _ H _)); eauto.
-    apply le_n_0_eq in H2.
+    apply Nat.le_0_r in H2.
     subst; auto.
   Qed.
 
@@ -4888,7 +4888,7 @@ Section CONTRACT.
     assert (exists n, num_occur_fds (inlined_fundefs_f f4 im') f n) by apply e_num_occur_fds.
     destruct H1. assert (x <= 0).
     eapply num_occur_fds_le_antimon; eauto.
-    apply le_n_0_eq in H2. subst; auto.
+    apply Nat.le_0_r in H2. subst; auto.
   Qed.
 
   Inductive sum_range_n: list var -> list var -> exp -> var -> nat -> Prop :=
@@ -5454,7 +5454,7 @@ Section CONTRACT.
       assert (x5 = 0). eapply (proj2 (num_occur_det _)); eauto. subst.
       simpl in H17. rewrite H2 in H17. inv H17.
       assert (m0 = 0). eapply (proj2 (num_occur_det _)); eauto. subst.
-      simpl. do 2 (rewrite plus_0_r).
+      simpl. do 2 (rewrite Nat.add_0_r).
       eapply (proj1 (num_occur_det _)); eauto.
     }
     assert (Hl0 := Decidable_FromList l0). destruct Hl0.
@@ -7253,13 +7253,13 @@ Section CONTRACT.
            | [ _ : context [inline_letapp ?E ?X ] |- _] => destruct (inline_letapp E X) as [[C' x''] | ] eqn:Hin'; inv Hin
            end); try congruence.
     - inv Hnum. pi0. eapply IHe in H4; eauto.
-      rewrite plus_comm. constructor. eassumption.
+      rewrite Nat.add_comm. constructor. eassumption.
     - inv Hnum. pi0. eapply IHe in H5; eauto. constructor. eassumption.
     - inv Hnum. pi0. eapply IHe in H5; eauto. constructor. eassumption.
     - inv Hnum. pi0. eapply IHe in Hin'; eauto. constructor; eauto.
     - inv Hin. inv Hnum. rewrite plus_n_O. econstructor. constructor.
     - inv Hnum. constructor. eauto.
-    - inv Hnum. pi0. eapply IHe in H4; eauto. rewrite plus_comm. constructor. eassumption.
+    - inv Hnum. pi0. eapply IHe in H4; eauto. rewrite Nat.add_comm. constructor. eassumption.
     - inv Hin. inv Hnum. dec_vars. constructor. 
   Qed.
 
@@ -7387,7 +7387,7 @@ Section CONTRACT.
         simpl in Heqs. eapply IHn in Heqs; eauto.
         * destructAll. unfold ce'.
           split.
-          -- rewrite plus_comm. eapply gsr_clos_trans. eassumption. eassumption.
+          -- rewrite Nat.add_comm. eapply gsr_clos_trans. eassumption. eassumption.
           -- now split; auto.
         * unfold term_sub_inl_size in *. simpl in *. lia.
         * intro. specialize (H2 v0). unfold ce in H2.
@@ -7561,7 +7561,7 @@ Section CONTRACT.
              eapply in_map with (f := (fun p : var * exp => let (k, e0) := p in (k, rename_all_ns sig e0))) in ftlc0. auto. } 
            unfold incr_steps in H6. remember (contract sig (dec_census_case sig l c0 (dec_census_list sig [v] count)) e sub inl) as s.
            symmetry in Heqs. destruct s as [[[[? ?] ?] ?] ?]. inv H6. eapply IHn in Heqs; eauto.
-           -- destructAll. split; eauto. rewrite plus_comm. eapply gsr_clos_trans. eassumption. eassumption.
+           -- destructAll. split; eauto. rewrite Nat.add_comm. eapply gsr_clos_trans. eassumption. eassumption.
            -- unfold term_sub_inl_size in *. simpl in *.
               assert ( term_size e < term_size (Ecase v l)).
               { eapply case_size. apply findtag_In. eauto. } 
@@ -7583,7 +7583,7 @@ Section CONTRACT.
              destruct H11. assert (x0 <= 0). eapply num_occur_case_le. 2: apply H14.
              apply findtag_In in ftlc0.
              eapply in_map with (f := (fun p : var * exp => let (k, e0) := p in (k, rename_all_ns sig e0))) in ftlc0.
-             now eauto. now eauto. apply le_n_0_eq in H12; subst; auto. dec_vars. eassumption.
+             now eauto. now eauto. apply Nat.le_0_r in H12; subst; auto. dec_vars. eassumption.
         * (* case not found, same as fun. contractcases_corresp with cl1 = nil and x = apply_r sig x*)
            remember (contractcases
                        (@pair (prod exp ctx_map) b_map
@@ -7655,7 +7655,7 @@ Section CONTRACT.
         assert (Hse := gsr_preserves_sig_dom _ _ _ _ H0 (closed_implies_Disjoint _ H1) H7 H5).
         unfold incr_steps in H6. remember (contract sig (dec_census_list sig [v0] count) e sub inl) as s. destruct s as [[[[? ?] ?] ?] ?].
         inv H6. symmetry in Heqs. apply IHn with (c := c) in Heqs; auto.
-        * destructAll. split; eauto. rewrite plus_comm. eapply gsr_clos_trans. eassumption. eassumption.
+        * destructAll. split; eauto. rewrite Nat.add_comm. eapply gsr_clos_trans. eassumption. eassumption.
         * unfold term_sub_inl_size in *. simpl. simpl in H. lia.
         * intro. specialize (H2 v1). apply num_occur_app_ctx in H2.
           destructAll. simpl in H6. inv H6. eapply num_occur_n.
@@ -7903,7 +7903,7 @@ Section CONTRACT.
                 rewrite H6 in *. destruct Heqs as (H6', H11).
                 destruct H11 as (H11, H12). destruct H12 as (H12, Hsigc). destructAll.
                 split; auto.
-                -- rewrite plus_comm. eapply gsr_clos_trans. eassumption. eassumption.
+                -- rewrite Nat.add_comm. eapply gsr_clos_trans. eassumption. eassumption.
                 -- split. now auto. split. now auto.
                    (* returned sig_inv_codom *)
                    intro. intros.
@@ -8169,7 +8169,7 @@ Section CONTRACT.
 
             apply andb_true_iff in Hel. destruct Hel as (Hel123, Hel4).
             apply andb_true_iff in Hel123. destruct Hel123 as (Hel12, Hel3).
-            eapply Peqb_true_eq in Hel12. apply beq_nat_true in Hel3. subst.
+            eapply Peqb_true_eq in Hel12. apply Nat.eqb_eq in Hel3. subst.
  
             assert (Hinbv : occurs_free (rename_all_ns sig (Eletapp v v0 f l e)) \subset
                             bound_stem_ctx (rename_all_ctx_ns sig (inlined_ctx_f c inl))).
@@ -8483,7 +8483,7 @@ Section CONTRACT.
                     (e := inlined_ctx_f (comp_ctx_f x (Efun1_c (fundefs_append x1 (Fcons (apply_r sig v0) f l0 e0 x2)) x0)) im') (sub' := sig) in H6;
                   [| eassumption ].
                 split; [| split; [| split ]].
-                + rewrite plus_comm. eapply gsr_clos_trans; [| eassumption ]. eassumption.
+                + rewrite Nat.add_comm. eapply gsr_clos_trans; [| eassumption ]. eassumption.
                 + unfold ce'.
                   erewrite (proj1 eq_P_rename_all_ctx_ns) in H9; [| eassumption ].
                   eassumption.
@@ -8499,11 +8499,12 @@ Section CONTRACT.
                   rewrite fundefs_append_bound_vars; [| reflexivity ]. normalize_bound_var. sets. }
               + (* size for IH *) 
                 unfold term_sub_inl_size in *; simpl in H. simpl.
-                eapply gt_S_n in H.
-                eapply le_S_gt. eapply lt_le_S.
-                eapply le_lt_trans. eapply plus_le_compat_r. eapply term_size_inline_letapp. eassumption.
-                rewrite (proj1 (term_size_rename_all_ns _)). rewrite (plus_comm (term_size e0)). rewrite <- plus_assoc.
-                rewrite (plus_comm (term_size e0)). erewrite <- sub_inl_fun_size; eauto.
+                eapply Nat.succ_lt_mono in H.
+                apply -> Nat.le_succ_l. apply -> Nat.le_succ_l.
+                eapply Nat.le_lt_trans.
+                apply -> Nat.add_le_mono_r. eapply term_size_inline_letapp. eassumption.
+                rewrite (proj1 (term_size_rename_all_ns _)). rewrite (Nat.add_comm (term_size e0)). rewrite <- Nat.add_assoc.
+                rewrite (Nat.add_comm (term_size e0)). erewrite <- sub_inl_fun_size; eauto.
               + (* unique bindings *)
                 rewrite Heq1, Heq2. eassumption.
               + (* closed *)
@@ -8974,7 +8975,8 @@ Section CONTRACT.
               apply sub_size_le. apply b_map_le_c. auto. symmetry in Heqp'. apply precontractfun_size in Heqp'.
               lia. auto. }
             assert ( S n >  funs_size f0 + sub_inl_size sub b0) by lia.
-            eapply gt_trans_S. apply H30. auto. }
+            eapply Nat.lt_le_trans; revgoals.
+            apply Nat.succ_le_mono. apply H30. auto. }
         * destruct Heqs as (Heqs1, (Heqs2, (Heqs3, (Heqs4, (Heqs5, Heqs6))))).
           rewrite H20 in *. simpl in *.
           assert (Heqs_ub := gsr_clos_preserves_clos _ _ _ H18 H19 Heqs1).
@@ -9011,13 +9013,13 @@ Section CONTRACT.
                 simpl. apply name_in_fundefs_rename_all_ns in H24. auto.            
           -- (* additional RW with Fun_dead_s on Fnil *)
              inv H6. split; [| split; [| split ] ]; eauto.
-             ++ rewrite <- minus_n_O in Heqs1. replace (n0 + n1 + 1) with (0 + ((n0 + n1) + 1)) by lia. eapply gsr_clos_trans. eassumption.
+             ++ rewrite Nat.sub_0_r in Heqs1. replace (n0 + n1 + 1) with (0 + ((n0 + n1) + 1)) by lia. eapply gsr_clos_trans. eassumption.
                 eapply gsr_clos_trans. eapply gsr_clos_trans. eassumption. eassumption.
                 replace 1 with (1 + 0) by lia. eapply Trans_srw;[| now eapply Refl_srw  ]. constructor. constructor. 
                 now apply Forall_nil.
              ++ intro. specialize (Heqs2 v). apply num_occur_app_ctx in Heqs2. destructAll.
                 apply num_occur_app_ctx. exists x, x0. inv H20. inv H28. split; auto.
-                split; auto. rewrite plus_0_r. auto.
+                split; auto. rewrite Nat.add_0_r. auto.
              ++ eapply inl_inv_mon. 2: apply Heqs3.
                 unfold ce'. do 2 (rewrite bound_var_app_ctx).
                 repeat normalize_bound_var. now sets.
@@ -9082,7 +9084,7 @@ Section CONTRACT.
           { (* function inlining *)
             apply andb_true_iff in Hel. destruct Hel as (Hel1, Hel23).
             apply andb_true_iff in Hel23. destruct Hel23 as (Hel2, Hel3).
-            apply Peqb_true_eq in Hel1. apply beq_nat_true in Hel2. subst.
+            apply Peqb_true_eq in Hel1. apply Nat.eqb_eq in Hel2. subst.
             assert (garvs' := garvs). apply H3 in garvs. destructAll. simpl in ce.
             (* sig v wasn't inlined before not dead *)
             assert (Hsvi : get_b (apply_r sig v) inl = false).
@@ -9464,7 +9466,7 @@ Section CONTRACT.
                 apply eq_P_set_list_not_in. auto. }
 
               split; [| split; [| split ]].
-              + rewrite plus_comm. eapply gsr_clos_trans. eassumption.
+              + rewrite Nat.add_comm. eapply gsr_clos_trans. eassumption.
                 unfold ce'. rewrite <- H_rn_ctx'. now apply H6.
               + unfold ce'. rewrite <- H_rn_ctx'. auto.
               + unfold ce'. rewrite <- H_rn_ctx'. auto.
@@ -9768,7 +9770,7 @@ Section CONTRACT.
       (*   remember (contract sig (dec_census_list sig l count) e sub inl) as s.  destruct s as [[[[? ?] ?] ?] ?]. inv H6. *)
       (*   symmetry in Heqs. simpl in ce. eapply IHn with (c := c) in Heqs. destructAll. *)
       (*   split; auto. *)
-      (*   rewrite plus_comm. eapply gsr_clos_trans. eassumption. eassumption. *)
+      (*   rewrite Nat.add_comm. eapply gsr_clos_trans. eassumption. eassumption. *)
       (*   unfold term_sub_inl_size in *.  simpl in *. lia. *)
       (*   eassumption. eassumption. *)
       (*   { (* count on dead prim pre *) *)

--- a/theories/LambdaANF/size_cps.v
+++ b/theories/LambdaANF/size_cps.v
@@ -102,13 +102,13 @@ Proof.
   revert H. generalize (M.elements rho).
   intros l Hin. induction l. now inv Hin.
   inv Hin.
-  - simpl. eapply le_trans. now apply Max.le_max_r.
+  - simpl. eapply Nat.le_trans. now apply Nat.le_max_r.
     eapply fold_left_extensive.
-    intros [y u] n; simpl. now apply Max.le_max_l.
-  - simpl. eapply le_trans. now eapply IHl; eauto. 
+    intros [y u] n; simpl. now apply Nat.le_max_l.
+  - simpl. eapply Nat.le_trans. now eapply IHl; eauto. 
     eapply fold_left_monotonic.
     intros. now eapply Nat.max_le_compat_r; eauto.
-    now apply Max.le_max_l.
+    now apply Nat.le_max_l.
 Qed.
 
 
@@ -162,11 +162,11 @@ Lemma sizeOf_val_Vconstr_unfold i t v l:
   max (sizeOf_val i v) (sizeOf_val i (Vconstr t l)).
 Proof.
   destruct i; simpl (sizeOf_val _ (Vconstr t _)); eauto.
-  rewrite <- (Max.max_0_l (sizeOf_val' (S i) v)).
+  rewrite <- (Nat.max_0_l (sizeOf_val' (S i) v)).
   unfold max_list_nat_with_measure.
   rewrite (fold_left_comm (fun (c : nat) (v0 : val) => Init.Nat.max c (sizeOf_val' (S i) v0))); eauto.
-  rewrite Max.max_comm, sizeOf_val_eq. reflexivity.
-  intros. now rewrite <- !Max.max_assoc, (Max.max_comm (sizeOf_val' (S i) y)).
+  rewrite Nat.max_comm, sizeOf_val_eq. reflexivity.
+  intros. now rewrite <- !Nat.max_assoc, (Nat.max_comm (sizeOf_val' (S i) y)).
 Qed.
 
 Lemma sizeOf_val_monotic i i' v :
@@ -267,9 +267,9 @@ Lemma max_list_nat_acc_spec {A} (xs : list A) f acc :
   max_list_nat_with_measure f acc xs =
   max acc (max_list_nat_with_measure f 0 xs).
 Proof.
-  rewrite <- (Max.max_0_r acc) at 1. generalize 0.
+  rewrite <- (Nat.max_0_r acc) at 1. generalize 0.
   revert acc. induction xs; intros acc n; simpl; eauto.
-  rewrite <- Max.max_assoc. eauto.
+  rewrite <- Nat.max_assoc. eauto.
 Qed.
 
 Lemma sizeOf_env_set_lists k rho rho' xs vs :
@@ -283,7 +283,7 @@ Proof.
   (*   simpl in Hset. destruct (set_lists xs vs rho) eqn:Hset'; try discriminate. *)
   (*   inv Hset. rewrite sizeOf_env_set; simpl. *)
   (*   rewrite max_list_nat_acc_spec. *)
-  (*   rewrite <- Max.max_assoc. eapply Nat.max_compat. reflexivity. *)
+  (*   rewrite <- Nat.max_assoc. eapply Nat.max_compat. reflexivity. *)
   (*   eauto. *)
 Abort.
 
@@ -307,13 +307,13 @@ Proof.
     destruct (rho ! a) eqn:Hgeta; try discriminate.
     destruct (get_list xs rho) eqn:Hgetl'; try discriminate.
     destruct vs; try discriminate. inv Hgetl. simpl.
-    eapply le_trans.
-    + rewrite <- (Max.max_0_l (sizeOf_val k v0)).
+    eapply Nat.le_trans.
+    + rewrite <- (Nat.max_0_l (sizeOf_val k v0)).
       unfold max_list_nat_with_measure.
       rewrite (fold_left_comm (fun (c : nat) (v : val) => Init.Nat.max c (sizeOf_val k v))).
       eapply Nat.max_le_compat. eapply IHxs. reflexivity.
       eapply sizeOf_env_get. eassumption.
-      intros x v1 v2. rewrite <- !Max.max_assoc, (Max.max_comm (sizeOf_val k v1)).
+      intros x v1 v2. rewrite <- !Nat.max_assoc, (Nat.max_comm (sizeOf_val k v1)).
       reflexivity.
     + eapply Nat.max_lub; lia.
 Qed.
@@ -372,7 +372,7 @@ Lemma fun_in_fundefs_sizeOf_exp B f tau xs e :
 Proof.
   intros Hin. induction B; inv Hin.
   - inv H. simpl; lia.
-  - eapply le_trans. eapply IHB; eauto.
+  - eapply Nat.le_trans. eapply IHB; eauto.
     simpl. lia.
 Qed.
 
@@ -386,8 +386,8 @@ Lemma max_exp_env_grt_1 k e rho :
   1 <= max_exp_env k e rho.
 Proof.
   unfold max_exp_env.
-  eapply le_trans. now apply sizeOf_exp_grt_1.
-  eapply Max.le_max_l.
+  eapply Nat.le_trans. now apply sizeOf_exp_grt_1.
+  eapply Nat.le_max_l.
 Qed.
 
 (** Lemmas used to establish the upper bound given the IH *)

--- a/theories/LambdaANF/stemctx.v
+++ b/theories/LambdaANF/stemctx.v
@@ -75,8 +75,8 @@ Import ListNotations.
              bound_stem_fundefs_ctx cfds v ->
              bound_stem_fundefs_ctx (Fcons2_c f t xs e cfds) v.
 
-  Hint Constructors bound_stem_ctx : core.
-  Hint Constructors bound_stem_fundefs_ctx : core.
+  #[global] Hint Constructors bound_stem_ctx : core.
+  #[global] Hint Constructors bound_stem_fundefs_ctx : core.
 
 
   Lemma bound_stem_Econstr_c x t ys c :
@@ -304,8 +304,8 @@ Import ListNotations.
 
 
   
-  Hint Constructors bound_not_stem_ctx : core.
-  Hint Constructors bound_not_stem_fundefs_ctx : core.
+  #[global] Hint Constructors bound_not_stem_ctx : core.
+  #[global] Hint Constructors bound_not_stem_fundefs_ctx : core.
 
   Lemma bound_not_stem_Econstr_c x t ys c :
     Same_set _ (bound_not_stem_ctx (Econstr_c x t ys c))

--- a/theories/LambdaANF/tactics.v
+++ b/theories/LambdaANF/tactics.v
@@ -34,7 +34,7 @@ Ltac destructAll :=
 Ltac pi0 :=
   repeat match goal with
          | [ H: _ + _ = 0 |- _ ] =>
-           apply plus_is_O in H; destruct H; subst
+           apply Nat.eq_add_0 in H; destruct H; subst
          | [ H: 0 = _ + _ |- _ ] =>
            symmetry in H; pi0
          (* | [ H: (if cps_util.var_dec ?X ?Y then _ else _) = 0 |- _] => *)

--- a/theories/LambdaANF/toplevel_theorems.v
+++ b/theories/LambdaANF/toplevel_theorems.v
@@ -83,7 +83,7 @@ Section Inline.
    - intros. eapply inline_bound_compat. eassumption.
    - intros. eapply inline_bound_post_Eapp_l.
    - intros. eapply inline_bound_remove_steps_letapp.
-   - intros. rewrite plus_comm. eapply inline_bound_remove_steps_letapp_OOT. 
+   - intros. rewrite Nat.add_comm. eapply inline_bound_remove_steps_letapp_OOT. 
    - reflexivity.
    - intro; intros. exact H0.
    - eapply H.

--- a/theories/LambdaANF/uncurry_rel.v
+++ b/theories/LambdaANF/uncurry_rel.v
@@ -2,7 +2,7 @@ Require Import LambdaANF.cps LambdaANF.size_cps LambdaANF.cps_util LambdaANF.eva
         LambdaANF.Ensembles_util LambdaANF.List_util LambdaANF.alpha_conv LambdaANF.functions LambdaANF.uncurry
         LambdaANF.shrink_cps_correct.
 Require Import FunInd.
-Require Import Coq.ZArith.Znumtheory Coq.Relations.Relations Coq.Arith.Wf_nat.
+Require Import Coq.ZArith.Znumtheory Coq.Relations.Relations Coq.Arith.Wf_nat Arith.
 Require Import Coq.Strings.String.
 Require Import Coq.Lists.List Coq.MSets.MSets Coq.MSets.MSetRBT Coq.Numbers.BinNums
         Coq.NArith.BinNat Coq.PArith.BinPos Coq.Sets.Ensembles micromega.Lia.
@@ -106,7 +106,7 @@ Section list_lemmas.
     length l = length (a ++ [b]) -> exists a1 b1, l = a1 ++ [b1].
   Proof.
     induction l; intros.
-    - rewrite app_length in H. inversion H. rewrite Plus.plus_comm in H1. inversion H1.
+    - rewrite app_length in H. inversion H. rewrite Nat.add_comm in H1. inversion H1.
     - destruct a0.
       + assert (l = []) by (destruct l; [easy|inversion H]). subst.
         now exists [], a.
@@ -325,8 +325,8 @@ with uncurry_fundefs_step :
       s' 
       (M.set g true m).
 
-Hint Constructors uncurry_step : core.
-Hint Constructors uncurry_fundefs_step : core.
+#[global] Hint Constructors uncurry_step : core.
+#[global] Hint Constructors uncurry_fundefs_step : core.
 
 Scheme uncurry_step_mut := Minimality for uncurry_step Sort Prop
 with uncurry_step_fundefs_mut := Minimality for uncurry_fundefs_step Sort Prop.
@@ -1397,7 +1397,7 @@ Corollary uncurry_fundefs_step_preserves_unique_bindings : forall f s m f1 s1 m1
   unique_bindings_fundefs f1.
 Proof. apply uncurry_step_preserves_unique_bindings_mut. Qed.
 
-Hint Constructors unique_bindings : core.
+#[global] Hint Constructors unique_bindings : core.
 
 Lemma uncurry_fundefs_step_unique_names : forall a f s m f1 s1 m1,
   used_vars_fundefs f \subset s ->
@@ -2091,8 +2091,8 @@ Inductive uncurry_rel_fundefs :
       uncurry_rel_fundefs n f1 s1 m1 f2 s2 m2 ->
       uncurry_rel_fundefs (S n) f s m f2 s2 m2.
 
-Hint Constructors uncurry_rel : core.
-Hint Constructors uncurry_rel_fundefs : core.
+#[global] Hint Constructors uncurry_rel : core.
+#[global] Hint Constructors uncurry_rel_fundefs : core.
 
 Lemma uncurry_rel_Sn : forall n e s m e1 s1 m1,
   uncurry_rel (S n) e s m e1 s1 m1 -> exists e2 s2 m2,

--- a/theories/LambdaBoxLocal/LambdaBoxMut_to_LambdaBoxLocal_correct.v
+++ b/theories/LambdaBoxLocal/LambdaBoxMut_to_LambdaBoxLocal_correct.v
@@ -1037,7 +1037,7 @@ Proof.
   intros.
   rewrite <- !(proj1 (trans_env_eval _ _ _ H)).
   rewrite trans_instantiate_any; auto.
-  equaln. rewrite <- minus_n_n.
+  equaln. rewrite Nat.sub_diag.
   now rewrite (proj1 shift0). 
 Qed.
 
@@ -1231,7 +1231,7 @@ with WNeutral : Term -> Prop :=
 | WNApp f a : WNeutral f -> WNorm a -> WNeutral (TApp f a)
 | WNCase mch n brs : WNeutral mch -> WNorms (terms_of_brs brs) -> WNeutral (TCase n mch brs).
 
-Hint Constructors WNorm WNeutral WNorms : core.
+#[global] Hint Constructors WNorm WNeutral WNorms : core.
 Scheme WNorm_ind' := Induction for WNorm Sort Prop
   with WNeutral_ind' := Induction for WNeutral Sort Prop
   with WNorms_ind' := Induction for WNorms Sort Prop.
@@ -1317,7 +1317,7 @@ Proof.
   revert bod; unfold sbst_fix, sbst_fix_aux.
   generalize (@eq_refl _ (efnlength es)).
   generalize (efnlength es) at 1 3.
-  generalize (le_refl (efnlength es)).
+  generalize (Nat.le_refl (efnlength es)).
   generalize es at 1 4 5 7.
   generalize (list_to_zero_spec (efnlength es)).
   induction (list_to_zero (efnlength es)); simpl; intros.
@@ -1406,7 +1406,7 @@ Lemma LambdaBoxMutsbst_fix_aux_sbst_fix_aux env prims e dts body :
 Proof.
   revert body.
   unfold LambdaBoxMutsbst_fix_aux, sbst_fix_aux.
-  generalize (le_refl (dlength dts)).
+  generalize (Nat.le_refl (dlength dts)).
   Opaque shift.
   simpl.
   generalize dts at 2 4 5 6 8 9 10.
@@ -1478,7 +1478,7 @@ Lemma find_branch_trans e prims (t : list name * Term) (i : inductive) (n : nat)
 Proof.
   assert(0 = N.of_nat (blength brs - blength brs)) by lia.
   revert H.
-  generalize (le_refl (blength brs)).
+  generalize (Nat.le_refl (blength brs)).
   assert(0 <= N.of_nat n) by lia.
   revert H.
   replace n with (n - N.to_nat 0)%nat at 2 4 by lia.

--- a/theories/LambdaBoxLocal/expression.v
+++ b/theories/LambdaBoxLocal/expression.v
@@ -841,7 +841,7 @@ Lemma pre_eval_evaln:
         forall m, m >= n -> evals_n (S m) es = Some vs).
 Proof.
   assert (j:forall m, m > 0 -> m = S (m - 1)).
-  { induction m; intuition. }
+  { induction m; intuition auto with arith. }
   apply my_eval_ind; intros; try (exists 0; intros mx h; reflexivity).
   - destruct H, H0, H1. exists (S (max x (max x0 x3))). intros m h.
     assert (j1:= max_fst x (max x0 x3)). 
@@ -1481,8 +1481,8 @@ Proof.
   inv H. lia.
   inv H0. auto.
   
-  inv H1. intuition.
-  inv H1. intuition.
+  inv H1. intuition auto.
+  inv H1. intuition auto.
 Qed.
 
 Lemma sbst_closed_id v :

--- a/theories/LambdaBoxLocal/fuel_sem.v
+++ b/theories/LambdaBoxLocal/fuel_sem.v
@@ -52,7 +52,7 @@ Fixpoint max_binders_branches (br : branches_e) : nat :=
 Section LambdaBoxLocal_fuel.
         
   Class LambdaBoxLocal_resource {A} :=
-  { HRes :> @resource exp A; }. 
+  { HRes :: @resource exp A; }. 
 
 End LambdaBoxLocal_fuel.
 

--- a/theories/LambdaBoxLocal/testL4.v
+++ b/theories/LambdaBoxLocal/testL4.v
@@ -15,7 +15,7 @@ Set Implicit Arguments.
 Set Printing Width 80.
 Set Printing Depth 1000.
 
-Instance fuel : utils.Fuel := { fuel := 2 ^ 14 }.
+#[global] Instance fuel : utils.Fuel := { fuel := 2 ^ 14 }.
 
 Quote Recursively Definition p_Type := Type.
 Print p_Type.

--- a/theories/LambdaBoxMut/program.v
+++ b/theories/LambdaBoxMut/program.v
@@ -50,7 +50,7 @@ Inductive Canonical : Term -> nat -> Terms -> Prop :=
           Canonical (TConstruct i n) n tnil
 | canA: forall (i:inductive) (n:nat) (t:Term) (ts:Terms),
           Canonical (TApp (TConstruct i n) t ts) n (tcons t ts).
-Hint Constructors Canonical : core.
+#[global] Hint Constructors Canonical : core.
 
 
 Lemma Canonical_dec:
@@ -196,7 +196,7 @@ Lemma Crct_Up:
 Proof.
   intros. eapply Crct_UP. eassumption. lia.
 Qed.
-Hint Resolve Crct_Up Crct_UP : core.
+#[global] Hint Resolve Crct_Up Crct_UP : core.
   
 Lemma CrctDs_Up:
   forall n p ds, crctDs p n ds -> forall m, n <= m -> crctDs p m ds.

--- a/theories/LambdaBoxMut/term.v
+++ b/theories/LambdaBoxMut/term.v
@@ -3,6 +3,7 @@ Require Import Coq.Lists.List.
 Require Import Coq.Strings.String.
 Require Import Coq.Arith.Compare_dec.
 Require Import Coq.Arith.Peano_dec.
+From Coq Require Import Arith.
 Require Import Coq.micromega.Lia.
 Require Import Common.Common.  (* shared namespace *)
 From MetaCoq.Utils Require Import bytestring. (* For identifier names *)
@@ -35,7 +36,7 @@ Definition isConstruct (t:Term) : Prop :=
 Lemma IsConstruct: forall i n args, isConstruct (TConstruct i n args).
 intros. exists i, n, args. reflexivity.
 Qed.
-Hint Resolve IsConstruct : core.
+#[global] Hint Resolve IsConstruct : core.
 Lemma isConstruct_dec: forall t, {isConstruct t}+{~ isConstruct t}.
 Proof.
   destruct t;
@@ -232,7 +233,7 @@ Definition isWrong (t:Term) : Prop :=  exists str, t = TWrong str.
 Lemma IsWrong: forall str, isWrong (TWrong str).
   intros. exists str. reflexivity.
 Qed.
-Hint Resolve IsWrong : core.
+#[global] Hint Resolve IsWrong : core.
 Lemma isWrong_dec: forall t, {isWrong t}+{~ isWrong t}.
 Proof.
   destruct t;
@@ -245,7 +246,7 @@ Definition isLambda (t:Term) : Prop :=
 Lemma IsLambda: forall nm bod, isLambda (TLambda nm bod).
 intros. exists nm, bod. reflexivity.
 Qed.
-Hint Resolve IsLambda : core.
+#[global] Hint Resolve IsLambda : core.
 Lemma isLambda_dec: forall t, {isLambda t}+{~ isLambda t}.
 induction t;
   try (solve [right; intros h; unfold isLambda in h;
@@ -970,7 +971,7 @@ Definition isFix (t:Term) : Prop :=
 Lemma IsFix: forall ds n, isFix (TFix ds n).
 intros. exists ds, n. reflexivity.
 Qed.
-Hint Resolve IsFix : core.
+#[global] Hint Resolve IsFix : core.
 
 Lemma isFix_dec: forall t, {isFix t}+{~ isFix t}.
 Proof.
@@ -984,7 +985,7 @@ Definition isProof (t:Term) : Prop := t = TProof.
 Lemma IsProof: isProof TProof.
 intros. reflexivity.
 Qed.
-Hint Resolve IsProof : core.
+#[global] Hint Resolve IsProof : core.
 Lemma isProof_dec: forall t, {isProof t}+{~ isProof t}.
 Proof.
   destruct t;
@@ -995,7 +996,7 @@ Defined.
 Inductive isCanonical : Term -> Prop :=
 | canC: forall (i:inductive) (n:nat) args, isCanonical (TConstruct i n args)
 | canP: isCanonical TProof.
-Hint Constructors isCanonical : core.
+#[global] Hint Constructors isCanonical : core.
 
 Lemma isCanonical_dec: forall t, isCanonical t \/ ~ isCanonical t.
 Proof.
@@ -1033,7 +1034,7 @@ Lemma tappend_tnil: forall ts:Terms, tappend ts tnil = ts.
 induction ts; simpl; try reflexivity.
 rewrite IHts. reflexivity.
 Qed.
-Hint Rewrite tappend_tnil : tappend.
+#[global] Hint Rewrite tappend_tnil : tappend.
 
 Lemma tappend_assoc:
   forall xts yts zts,
@@ -1251,7 +1252,7 @@ Lemma tnth_extend1:
   forall n l t,  tnth n l = Some t -> n < tlength l.
 Proof.
   induction n; induction l; simpl; intros; try discriminate; try lia.
-  - apply Lt.lt_n_S. eapply IHn. eassumption.
+  - apply -> Nat.succ_lt_mono. eapply IHn. eassumption.
 Qed.
 
 Lemma tnth_extend2:
@@ -1260,7 +1261,7 @@ Proof.
   induction n; intros.
   - destruct l. simpl in H. lia. exists t. reflexivity.
   - destruct l. inversion H. simpl in H.
-    specialize (IHn _ (Lt.lt_S_n _ _ H)). destruct IHn. exists x.
+    specialize (IHn _ (proj2 (Nat.succ_lt_mono _ _) H)). destruct IHn. exists x.
     simpl. assumption.
 Qed.
 
@@ -1627,7 +1628,7 @@ with WFappDs: Defs -> Prop :=
      | wfadcons: forall nm bod arg ds,
          WFapp bod -> WFappDs ds ->
          WFappDs (dcons nm bod arg ds).
-Hint Constructors WFapp WFapps WFappBs WFappDs : core.
+#[global] Hint Constructors WFapp WFapps WFappBs WFappDs : core.
 Scheme WFapp_ind' := Minimality for WFapp Sort Prop
   with WFapps_ind' := Minimality for WFapps Sort Prop
   with WFappBs_ind' := Minimality for WFappBs Sort Prop
@@ -1903,7 +1904,7 @@ with WFTrmDs: Defs -> nat -> Prop :=
      | wfdcons: forall n nm bod arg ds,
          WFTrm bod n -> WFTrmDs ds n ->
          WFTrmDs (dcons nm bod arg ds) n.
-Hint Constructors WFTrm WFTrms WFTrmBs WFTrmDs : core.
+#[global] Hint Constructors WFTrm WFTrms WFTrmBs WFTrmDs : core.
 Scheme WFTrm_ind' := Minimality for WFTrm Sort Prop
   with WFTrms_ind' := Minimality for WFTrms Sort Prop
   with WFTrmBs_ind' := Minimality for WFTrmBs Sort Prop

--- a/theories/LambdaBoxMut/test_wcbvEval.v
+++ b/theories/LambdaBoxMut/test_wcbvEval.v
@@ -17,7 +17,7 @@ Set Implicit Arguments.
 Set Printing Width 80.
 Set Printing Depth 1000.
 
-Instance fuel : utils.Fuel := { fuel := 2 ^ 14 }.
+#[global] Instance fuel : utils.Fuel := { fuel := 2 ^ 14 }.
 
 Quote Recursively Definition p_Type := Type.
 Print p_Type.
@@ -1306,7 +1306,7 @@ Definition cp_term :=    (* Transparent *)
                           (fun k:nat =>
                            match k as n1 return (S v < n1 -> forall def:nat -> nat, Recdef.iter (nat -> nat) n1 copy_F def (S p) = S rec_res) with
                            | 0 => fun h0:S v < 0 => False_ind (forall def:nat -> nat, Recdef.iter (nat -> nat) 0 copy_F def (S p) = S rec_res) (Nat.nlt_0_r (S v) h0)
-                           | S k0 => fun (h':S v < S k0) (def:nat -> nat) => eq_ind_r (fun n1:nat => S n1 = S rec_res) eq_refl (H2 k0 (Nat.le_lt_trans x v k0 l0 (lt_S_n v k0 h')) def)
+                           | S k0 => fun (h':S v < S k0) (def:nat -> nat) => eq_ind_r (fun n1:nat => S n1 = S rec_res) eq_refl (H2 k0 (Nat.le_lt_trans x v k0 l0 (Nat.succ_lt_mono v k0 h')) def)
                            end)) (max 0 x)) p2)) (hrec p (Acc_inv Acc_n0 (eq_ind_r (fun n1:nat => p < n1) (H0 n0 p teq) teq)))
         end eq_refl) n Acc_n) _TmpHyp) H) copy_tcc.
 

--- a/theories/LambdaBoxMut/wcbvEval.v
+++ b/theories/LambdaBoxMut/wcbvEval.v
@@ -67,7 +67,7 @@ with WcbvEvals (p:environ Term) : Terms -> Terms -> Prop :=
      | wCons: forall t t' ts ts',
          WcbvEval p t t' -> WcbvEvals p ts ts' -> 
          WcbvEvals p (tcons t ts) (tcons t' ts').
-Hint Constructors WcbvEval WcbvEvals : core.
+#[global] Hint Constructors WcbvEval WcbvEvals : core.
 Scheme WcbvEval1_ind := Induction for WcbvEval Sort Prop
      with WcbvEvals1_ind := Induction for WcbvEvals Sort Prop.
 Combined Scheme WcbvEvalEvals_ind from WcbvEval1_ind, WcbvEvals1_ind.
@@ -296,7 +296,7 @@ Qed.
 Section wcbvEval_sec.
 Variable p:environ Term.
 
-Instance fix_bug : MonadExc.MonadExc string exception := exn_monad_exc.
+#[global] Instance fix_bug : MonadExc.MonadExc string exception := exn_monad_exc.
 
 (** now an executable weak-call-by-value evaluation **)
 (** use a timer to make this terminate **)

--- a/theories/Makefile.local
+++ b/theories/Makefile.local
@@ -1,1 +1,0 @@
-OTHERFLAGS = "-w" "-deprecated-hint-without-locality" "-w" "-deprecated-instance-without-locality" "-w" "-deprecated-hint-rewrite-without-locality"

--- a/theories/common/CertiClasses/certiClasses.v
+++ b/theories/common/CertiClasses/certiClasses.v
@@ -8,7 +8,7 @@ CoInductive liftLe {S D: Type} (R: S -> D -> Prop): option S -> option D -> Prop
 | liftSome: forall s d, R s d -> liftLe R (Some s) (Some d)
 | liftNone: forall d, liftLe R None d.
 
-Hint Constructors liftLe : certiclasses.
+#[global] Hint Constructors liftLe : certiclasses.
 
 (** is this defined in the Coq standard library of ExtLib? *)
 Definition Rimpl {S D: Type} (R1 R2: S -> D -> Prop) :=
@@ -45,7 +45,7 @@ Proof.
   apply Hr. assumption.
 Defined.
 
-Hint Resolve liftLeRimpl : certiclasses.
+#[global] Hint Resolve liftLeRimpl : certiclasses.
 
 (* This operations picks out the "good" terms in the language.
  All bets are off about the terms that are not good *)
@@ -118,7 +118,7 @@ Class BigStepOpSemExecCorrect {Term Value:Type}
   }.
       
 
-Instance liftBigStepException `{BigStepOpSem Term Value} 
+#[global] Instance liftBigStepException `{BigStepOpSem Term Value} 
   : BigStepOpSem (exception Term) (exception Value) :=
 λ (s : exception Term) (sv : exception Value),
 match (s, sv) with
@@ -144,7 +144,7 @@ Class CerticoqTotalTranslation (Src Dst : Type) : Type
 Arguments translate  Src Dst {CerticoqTranslation} s.
 Arguments translateT  Src Dst {CerticoqTotalTranslation} s.
 
-Instance liftTotal `{CerticoqTotalTranslation Src Dst} : CerticoqTranslation Src Dst :=
+#[global] Instance liftTotal `{CerticoqTotalTranslation Src Dst} : CerticoqTranslation Src Dst :=
   fun opt (x:Src) => Ret (translateT Src Dst opt x). 
 
 

--- a/theories/common/CertiClasses/certiClassesLinkable.v
+++ b/theories/common/CertiClasses/certiClassesLinkable.v
@@ -586,7 +586,7 @@ Proof using mkAppCongrLe.
   eauto.
 Qed.
 
-Instance mkAppRW : Proper (eq ==> eqObsId ==> eqObsId) (@mkApp Dst _).
+#[global] Instance mkAppRW : Proper (eq ==> eqObsId ==> eqObsId) (@mkApp Dst _).
 Proof using.
   intros ? ? ? ? ? ?. subst.
   apply mkAppCongr.

--- a/theories/common/RandyPrelude.v
+++ b/theories/common/RandyPrelude.v
@@ -371,7 +371,7 @@ Definition no_step {A:Set} (R:A -> A -> Prop) (a:A) :=
   forall (b:A), ~ R a b.
 
 Lemma neq_sym: forall (A:Type) (a b:A), a <> b -> b <> a.
-  intuition.
+  intuition auto.
 Qed.
 
 Function list_to_zero (n:nat) : list nat :=
@@ -442,11 +442,11 @@ Fixpoint exnNth (A:Type) (xs:list A) (n:nat) : exception A :=
   end.
 
 Lemma bool_not_neq: forall (b1 b2:bool), (~ b1 <> b2) <-> b1 = b2.
-  split; induction b1; induction b2; intuition.
+  split; induction b1; induction b2; intuition auto.
 Qed.
 
 Lemma bool_neq_false: forall (b:bool), (b <> false) <-> b = true.
-  split; induction b; intuition.
+  split; induction b; intuition auto.
 Qed.
 
 Lemma bs_not_cons_bs:
@@ -457,7 +457,7 @@ Lemma bs_not_cons_bs:
 Qed.
 
 Lemma deMorgan_impl: forall (A B:Prop), (A -> B) -> (~B -> ~A).
-  intuition.
+  intuition auto.
 Qed.
 
 Lemma orb3_true_elim:
@@ -467,16 +467,16 @@ Lemma orb3_true_elim:
   assert (j1: {b1 = true} + {b2 || b3 = true}).
   { apply orb_true_elim. rewrite orb_assoc. assumption. }
   destruct j1.
-  - intuition.
+  - intuition auto.
   - assert (j2: {b2 = true} + {b3 = true}). apply (orb_true_elim _ _ e).
-    destruct j2; intuition.
+    destruct j2; intuition auto.
 Qed.  
 
 Lemma fold_left_bool_mono:
   forall (ds:list bool),
     fold_left (fun (b c:bool) => b || c) ds false = true ->
     fold_left (fun (b c:bool) => b || c) ds true = true.
-  induction ds; intro h; intuition. induction a. 
+  induction ds; intro h; intuition auto. induction a. 
   - exact h.
   - simpl. simpl in h. apply (IHds h).
 Qed.
@@ -510,7 +510,7 @@ Qed.
 Lemma nat_compare_EQ: forall n, Nat.compare n n = Eq.
   intro n. apply (proj2 (Nat.compare_eq_iff n n)). reflexivity.
 Qed.
-Hint Rewrite nat_compare_EQ : core.
+#[global] Hint Rewrite nat_compare_EQ : core.
 
 Lemma notNone_Some:
   forall (A:Type) (o:option A), o <> None -> exists a, o = Some a.
@@ -537,9 +537,9 @@ induction m; simpl; reflexivity.
 Qed.
 
 Lemma max_fst: forall m n, max m n >= m.
-induction m; induction n; simpl; intuition.
+induction m; induction n; simpl; intuition auto with arith.
 Qed.
 
 Lemma max_snd: forall m n, max m n >= n.
-induction m; induction n; simpl; intuition.
+induction m; induction n; simpl; intuition auto with arith.
 Qed.

--- a/theories/common/classes.v
+++ b/theories/common/classes.v
@@ -12,7 +12,7 @@ Class Eq (A:Type) :=
     eq_dec : forall (x y:A), {x = y} + {x<>y}
   }.
 
-Instance NatEq: Eq nat := { eq_dec := eq_nat_dec }.
-Instance AsciiEq: Eq ascii := { eq_dec:= ascii_dec }.
-Instance StringEq: Eq string := { eq_dec:= string_dec }.
+#[global] Instance NatEq: Eq nat := { eq_dec := eq_nat_dec }.
+#[global] Instance AsciiEq: Eq ascii := { eq_dec:= ascii_dec }.
+#[global] Instance StringEq: Eq string := { eq_dec:= string_dec }.
 

--- a/theories/common/exceptionMonad.v
+++ b/theories/common/exceptionMonad.v
@@ -42,7 +42,7 @@ intros.
 induction a; repeat reflexivity.
 Qed.
 
-Instance exn_monad : Monad exception :=
+#[global] Instance exn_monad : Monad exception :=
   { ret := @ret; bind := @bind }.
 
 Definition catch {T} (e : exception T) (f : string -> exception T) : exception T :=
@@ -51,7 +51,7 @@ Definition catch {T} (e : exception T) (f : string -> exception T) : exception T
   | Exc s => f s
   end.
 
-Instance exn_monad_exc : MonadExc string (fun A => exception A) :=
+#[global] Instance exn_monad_exc : MonadExc string (fun A => exception A) :=
   { raise := @raise; catch := @catch }.
 
 Definition econs

--- a/theories/common/mapenv.v
+++ b/theories/common/mapenv.v
@@ -87,7 +87,7 @@ Inductive Lookup: string -> environ -> envClass trm -> Prop :=
 | LHit: forall s p t, Lookup s (define s t p) t
 | LMiss: forall s1 s2 p t ec,
            s2 <> s1 -> Lookup s2 p ec -> Lookup s2 (define s1 t p) ec.
-Hint Constructors Lookup : core.
+#[global] Hint Constructors Lookup : core.
 Definition LookupDfn s p t := Lookup s p (ecTrm t).
 Definition LookupTyp s p n i := Lookup s p (ecTyp trm n i) /\ i <> nil.
 Definition LookupAx s p := Lookup s p (ecAx trm).

--- a/theories/common/references.v
+++ b/theories/common/references.v
@@ -23,11 +23,11 @@ Class Eqb (A : Type) :=
   { eqb : A -> A -> bool }.
 
 (* TODO improve *)
-Instance ascii_eq : Eqb ascii :=
+#[global] Instance ascii_eq : Eqb ascii :=
   { eqb s s' := if ascii_dec s s' then true else false }.
 
 (* TODO improve *)
-Instance string_eq : Eqb string :=
+#[global] Instance string_eq : Eqb string :=
   { eqb s s' := if string_dec s s' then true else false }.
 
 Definition reforder {A} (f : A -> A -> comparison) :=
@@ -93,7 +93,7 @@ Proof.
               end); simpl; reflexivity.
 Admitted.
 
-Instance ascii_reftype : ReferenceType ascii.
+#[global] Instance ascii_reftype : ReferenceType ascii.
 Proof.
   refine {| reference_compare := ascii_compare |}.
   intro. exact Space. intro c. exact (String c EmptyString).
@@ -109,7 +109,7 @@ Proof.
   rewrite N.compare_lt_iff in *. N.order.
 Defined.
   
-Instance string_reftype : ReferenceType string.
+#[global] Instance string_reftype : ReferenceType string.
 Proof.
   refine {| reference_compare := string_compare |}.
   exact id. exact id.


### PR DESCRIPTION
This fixes all Coq deprecations in theories/, making the build log much more readable. Some notations that were used have disappeared from following Coq versions.