### PR TITLE
Make the ocamlfind and gcc/clang relative to the current environment …

### DIFF
--- a/.vscode/CertiCoq.code-workspace
+++ b/.vscode/CertiCoq.code-workspace
@@ -4,12 +4,4 @@
 			"path": ".."
 		}
 	],
-	"settings": {
-		"coqtop.binPath": "_opam/bin",
-		"coqtop.args": [],
-		"ocaml.sandbox": {
-			"kind": "opam",
-			"switch": "coq817"
-		}
-	}
 }


### PR DESCRIPTION
…or a specified CertiCoq ocamlfind/CC option (giving the executable path as argument).

Fixes hardcoded paths which might work only for me in the previous PR.