### PR TITLE
Certicoq runtime / include cleanup

### DIFF
--- a/benchmarks/certicoq_eval_issue.v
+++ b/benchmarks/certicoq_eval_issue.v
@@ -26,20 +26,24 @@ Print nth.
 Extraction nth.
 
 From CertiCoq.Plugin Require Import CertiCoq.
+Set CertiCoq Build Directory "_build".
 
 Import ListNotations.
-Definition l : list nat := map (fun x => x * x) (repeat 3 45000).
+Definition l : list nat := map (fun x => x * x) (repeat 3 4000).
 
-Lemma nth_l : 30000 < length l.
+Lemma nth_l : 3000 < length l.
 Proof. unfold l. rewrite map_length. rewrite repeat_length. Admitted.
 
-Definition test : nat := (nth l (30000; nth_l)).
+Definition test : nat := (nth l (3000; nth_l)).
 (* Time Eval vm_compute in test. *)
 (* 30 seconds, includes cost of building the intermediate n < length proofs  *)
-(* Stack overflowing? *)
+(* Stack overflowing when replacing 4000 with 45000 for example? *)
 (* CertiCoq Eval -debug -time test. *)
 Definition largenat := 45000.
 (* Stack overflowing? *)
 
 Definition llength := length l.
 CertiCoq Eval -debug -time llength.
+
+Time Eval vm_compute in llength.
+Time Eval native_compute in llength.

--- a/benchmarks/test_primitive.v
+++ b/benchmarks/test_primitive.v
@@ -12,7 +12,7 @@ CertiCoq Run cst.
 
 From Bignums Require Import BigN.
 Local Open Scope bigN_scope.
-From MetaCoq Require Import Loader.
+From MetaCoq.ErasurePlugin Require Import Loader.
 
 (* From MetaCoq.Erasure Require Import Loader. *)
  

--- a/plugin/CoqMsgFFI.v
+++ b/plugin/CoqMsgFFI.v
@@ -11,4 +11,4 @@ CertiCoq Register [
   coq_msg_notice => "coq_msg_notice",
   coq_msg_debug => "coq_msg_debug",
   coq_user_error => "coq_user_error" ]
-Include [ "coq_ffi.h" as library ].
+Include [ "coq_c_ffi.h" "coq_ffi.h" as library ].

--- a/plugin/g_certicoq.mlg
+++ b/plugin/g_certicoq.mlg
@@ -80,7 +80,7 @@ END
 VERNAC ARGUMENT EXTEND cinclude
 | [ string(str) ] -> { FromRelativePath str }
 | [ string(str) "as" "absolute" ] -> { FromAbsolutePath str }
-| [ string(str) "as" "library" ] -> { FromLibrary str }
+| [ string(str) string_opt(str') "as" "library" ] -> { FromLibrary (str, str') }
 END
 
 VERNAC COMMAND EXTEND CertiCoq_Register CLASSIFIED AS SIDEFF

--- a/plugin/plugin_utils.ml
+++ b/plugin/plugin_utils.ml
@@ -6,7 +6,7 @@ open Caml_bytestring
 type import =
     FromRelativePath of string
   | FromAbsolutePath of string
-  | FromLibrary of string
+  | FromLibrary of string * string option
 
 let string_of_bytestring = caml_string_of_bytestring
 let bytestring_of_string = bytestring_of_caml_string
@@ -16,9 +16,9 @@ let bytestring_of_string = bytestring_of_caml_string
 let extract_constant (g : Names.GlobRef.t) (s : string) : (Kernames.kername * Kernames.ident)  =
   match g with
   | Names.GlobRef.ConstRef c -> (Obj.magic (quote_kn (Names.Constant.canonical c)), bytestring_of_caml_string s)
-  | Names.GlobRef.VarRef(v) -> CErrors.user_err ~hdr:"extract-constant" (str "Expected a constant but found a variable. Only constants can be realized in C.")
-  | Names.GlobRef.IndRef(i) -> CErrors.user_err ~hdr:"extract-constant" (str "Expected a constant but found an inductive type. Only constants can be realized in C.")
-  | Names.GlobRef.ConstructRef(c) -> CErrors.user_err ~hdr:"extract-constant" (str "Expected a constant but found a constructor. Only constants can be realized in C. ")
+  | Names.GlobRef.VarRef(v) -> CErrors.user_err (str "Expected a constant but found a variable. Only constants can be realized in C.")
+  | Names.GlobRef.IndRef(i) -> CErrors.user_err (str "Expected a constant but found an inductive type. Only constants can be realized in C.")
+  | Names.GlobRef.ConstructRef(c) -> CErrors.user_err (str "Expected a constant but found a constructor. Only constants can be realized in C. ")
 
 let rec debug_mappings (ms : (Kernames.kername * Kernames.ident) list) : unit =
   match ms with
@@ -32,8 +32,10 @@ let rec debug_mappings (ms : (Kernames.kername * Kernames.ident) list) : unit =
      
 let help_msg : string =
   "Usage:\n\
-To compile an Gallina definition named <gid> type:\n\
+To compile a Gallina definition named <gid> type:\n\
    CertiCoq Compile <options> <gid>.\n\n\
+To evaluate a Gallina definition named <gid> type:\n\
+   CertiCoq Eval <options> <gid>.\n\n\
 To show this help message type:\n\
    CertiCoq -help.\n\n\
 To produce an .ir file with the last IR (lambda-anf) of the compiler type:\n\
@@ -50,5 +52,7 @@ Valid options:\n\
 -time_anf :  Time λanf optimizations\n\
 \n\n\
 To compile Gallina constants to specific C functions use:\n\
-   CertiCoq Compile <options> <gid> Extract Constants [ constant1 => \"c_function1\", ... , constantN => \"c_functionN\" ] Include [ \"file1.h\", ... , \"fileM.h\" ]."
+   CertiCoq Compile <options> <gid> Extract Constants [ constant1 => \"c_function1\", ... , constantN => \"c_functionN\" ] Include [ \"file1.h\" as library, ... , \"fileM.h\" as library ].\n\
+\n\
+See https://github.com/CertiCoq/certicoq/wiki/The-CertiCoq-plugin for more detailed information."
 

--- a/plugin/plugin_utils.mli
+++ b/plugin/plugin_utils.mli
@@ -1,7 +1,7 @@
 type import =
     FromRelativePath of string
   | FromAbsolutePath of string
-  | FromLibrary of string
+  | FromLibrary of string * string option
 
 val string_of_bytestring : Bytestring.String.t -> string
 

--- a/plugin/runtime/Makefile
+++ b/plugin/runtime/Makefile
@@ -1,5 +1,5 @@
-SRC = gc_stack.c certicoq_run_main.c certicoq_run.c coq_c_ffi.c coq_ffi.c prim_int63.c prim_floats.c
-HEADERS = m.h config.h values.h gc_stack.h certicoq_run_main.h certicoq_run.h coq_c_ffi.h coq_ffi.h prim_int63.h prim_floats.h
+SRC = gc_stack.c certicoq_run_main.c coq_c_ffi.c coq_ffi.c prim_int63.c prim_floats.c
+HEADERS = m.h config.h values.h gc_stack.h certicoq_run_main.h coq_c_ffi.h coq_ffi.h prim_int63.h prim_floats.h
 LINKOPTS = -linkpkg -dontlink str,unix,dynlink,threads,zarith
 
 TARGETS = ${SRC:.c=.o}

--- a/plugin/runtime/coq_c_ffi.c
+++ b/plugin/runtime/coq_c_ffi.c
@@ -44,7 +44,7 @@ value coq_user_error(value msg) {
   char *str = string_of_coq_string(msg);
   fputs(str, stderr);
   free(str);
-  return 1;
+  exit(1);
 }
 
 value coq_msg_debug(value msg) {


### PR DESCRIPTION
Also fix CertiCoq run when using CoqMsgFFI functions. 