### PR TITLE
Implement and verify the naive translation of lazy/force to thunks

### DIFF
--- a/benchmarks/TESTS
+++ b/benchmarks/TESTS
@@ -6,3 +6,4 @@ vs_hard
 binom
 color
 sha_fast
+lazy_factorial

--- a/benchmarks/tests.v
+++ b/benchmarks/tests.v
@@ -69,7 +69,7 @@ Definition color := Color.main.
 
 (* Lazy factorial. Needs coinductive types *)
 
-(* Definition lazy_factorial := coq_msg_info (string_of_Z (coind.lfact 150)). *)
+Definition lazy_factorial := string_of_Z (coind.lfact 150).
 
 (* Sha *)
 
@@ -116,6 +116,14 @@ CertiCoq Compile -args 1000 -config 9 -O 1 -ext "_opt_ll" list_sum.
 (* CertiCoq Compile -cps -ext "_cps_opt" list_sum. *)
 CertiCoq Generate Glue -file "glue_list_sum" [ nat ].
 
+Eval compute in "Compiling lazy factorial (using unsafe passes)".
+
+CertiCoq Compile -unsafe-erasure -O 1 lazy_factorial.
+CertiCoq Compile -unsafe-erasure -ext "_opt" lazy_factorial.
+CertiCoq Compile -unsafe-erasure -args 1000 -config 9 -O 1 -ext "_opt_ll" lazy_factorial. 
+(* CertiCoq Compile -O 0 -cps -ext "_cps" demo1. *)
+(* CertiCoq Compile -cps -ext "_cps_opt" demo1. *)
+CertiCoq Generate Glue -file "glue_lazy_factorial" [ ].
 
 Eval compute in "Compiling vs_easy".
 
@@ -144,15 +152,6 @@ CertiCoq Compile -args 1000 -config 9 -O 1 -ext "_opt_ll" binom.
 (* CertiCoq Compile -O 0 -cps -ext "_cps" binom. *)
 (* CertiCoq Compile -cps -ext "_cps_opt" binom. *)
 CertiCoq Generate Glue -file "glue_binom" [ nat ].
-
-(* Eval compute in "Compiling lazy factorial". *)
-
-(* CertiCoq Compile -O 1 lazy_factorial.
-CertiCoq Compile -ext "_opt" lazy_factorial.
-CertiCoq Compile -args 1000 -config 9 -O 1 -ext "_opt_ll" lazy_factorial. *)
-(* CertiCoq Compile -O 0 -cps -ext "_cps" demo1. *)
-(* CertiCoq Compile -cps -ext "_cps_opt" demo1. *)
-(* CertiCoq Generate Glue -file "glue_lazy_factorial" [ ]. *)
 
 
 Eval compute in "Compiling color".

--- a/theories/LambdaBoxMut/program.v
+++ b/theories/LambdaBoxMut/program.v
@@ -279,6 +279,26 @@ Proof.
     + apply LMiss; assumption.
 Qed.
 
+Lemma Crct_lift:
+  (forall p n t, crctTerm p n t -> forall k, crctTerm p (S n) (lift k t)) /\
+  (forall p n ts, crctTerms p n ts -> forall k, crctTerms p (S n) (lifts k ts)) /\
+  (forall p n ts, crctBs p n ts -> forall k, crctBs p (S n) (liftBs k ts)) /\
+  (forall p n ts, crctDs p n ts -> forall k, crctDs p (S n) (liftDs k ts)) /\
+  (forall p, crctEnv p -> crctEnv p).
+Proof.
+  apply crctCrctsCrctBsDsEnv_ind; intros;
+  try (solve[cbn; repeat econstructor; intuition eauto]).
+  (* 2-9:try (econstructor; intuition auto); try eassumption. *)
+  - cbn. constructor; eauto. destruct (Nat.compare_spec m k); subst; try lia.
+  - cbn. econstructor; eauto. inversion_Clear H. econstructor; eauto.
+    now rewrite lifts_pres_tlength.
+  - econstructor; eauto.
+  - cbn. constructor; eauto. rewrite liftDs_pres_dlength. eauto.
+    rewrite liftDs_pres_dlength; lia.
+  - cbn. constructor; eauto. now rewrite Nat.add_succ_r.
+  - cbn. constructor; eauto. destruct H as [na [body ->]]. now do 2 eexists.
+Qed.
+
 Lemma Crct_weaken_Typ:
   (forall p n t, crctTerm p n t -> 
                  forall nm s, fresh nm p ->


### PR DESCRIPTION
This is based on the latest metacoq, whose -unsafe-erasure includes a translation from cofixpoints to fix + lazy/force (yet unverified, as this requires a fair bit of knowledge about the productivity condition). So CertiCoq now supports cofixpoints when used with that pipeline. We do the lazy/force translation to lambdas/applications in the first translation phase and verify that it mimicks the reduction rules of lazy/force. We add a lazy factorial test in the benchmarks.