### PR TITLE
opam: remove with-test commands

### DIFF
--- a/coq-certicoq.opam
+++ b/coq-certicoq.opam
@@ -23,8 +23,6 @@ build: [
   [make "all"]
   [make "plugins"]
   [make "bootstrap"]
-  [make "-C" "benchmarks" "all"] {with-test}
-  [make "-C" "bootstrap" "tests"] {with-test}
 ]
 install: [
   [make "install"]


### PR DESCRIPTION
They are meant to be executed with an installed certicoq so won't work in the build step.