### PR TITLE
Requires OCaml 4.13

### DIFF
--- a/coq-certicoq.opam
+++ b/coq-certicoq.opam
@@ -30,7 +30,7 @@ install: [
   [make "install"]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {>= "4.13"}
   "conf-clang"
   "stdlib-shims"
   "coq" {>= "8.19" & < "8.20~"}


### PR DESCRIPTION
https://github.com/CertiCoq/certicoq/blob/7af861abb6521ca636720b3a1cce7d0d84eea7fa/plugin/certicoq.ml#L56

[`String.of_bytes`](https://ocaml.org/manual/5.2/api/String.html#:~:text=val%20of_bytes%20%3A,Since%204.13) was first introduced in ocaml/ocaml#9448