### PR TITLE
chore: fix typo in `smgd_trans`: use `map_getd_r` instead of `map_get_r`

### DIFF
--- a/libraries/maps_util.v
+++ b/libraries/maps_util.v
@@ -195,7 +195,7 @@ Qed.
 
 Theorem smg_trans: forall t, Transitive (map_get_r t).
 Proof.
- intros t sub sub' sub''.  unfold map_get_r. intros. specialize (H v). specialize (H0 v). rewrite H. assumption.
+ intros t sub sub' sub''.  unfold map_getd_r. intros. specialize (H v). specialize (H0 v). rewrite H. assumption.
 Qed.
 
 


### PR DESCRIPTION
Noticed a typo in `smgd_trans` — the function was incorrectly calling `map_get_r` instead of `map_getd_r`.
This fixes that.